### PR TITLE
Add support for multiple statuses search in PromotionRepository

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PromotionCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/PromotionCriteria.java
@@ -27,13 +27,13 @@ import java.util.List;
 public class PromotionCriteria {
 
     private List<String> targetEnvCockpitIds;
-    private PromotionStatus status;
+    private List<PromotionStatus> statuses;
     private Boolean targetApiExists;
     private String apiId;
 
     PromotionCriteria(Builder builder) {
         this.targetEnvCockpitIds = builder.targetEnvCockpitIds;
-        this.status = builder.status;
+        this.statuses = builder.statuses;
         this.targetApiExists = builder.targetApiExists;
         this.apiId = builder.apiId;
     }
@@ -46,12 +46,12 @@ public class PromotionCriteria {
         this.targetEnvCockpitIds = targetEnvCockpitIds;
     }
 
-    public PromotionStatus getStatus() {
-        return status;
+    public List<PromotionStatus> getStatuses() {
+        return statuses;
     }
 
-    public void setStatus(PromotionStatus status) {
-        this.status = status;
+    public void setStatuses(List<PromotionStatus> statuses) {
+        this.statuses = statuses;
     }
 
     public Boolean getTargetApiExists() {
@@ -73,7 +73,7 @@ public class PromotionCriteria {
     public static class Builder {
 
         private List<String> targetEnvCockpitIds;
-        private PromotionStatus status;
+        private List<PromotionStatus> statuses;
         private Boolean targetApiExists;
         private String apiId;
 
@@ -82,8 +82,8 @@ public class PromotionCriteria {
             return this;
         }
 
-        public Builder status(PromotionStatus status) {
-            this.status = status;
+        public Builder statuses(List<PromotionStatus> statuses) {
+            this.statuses = statuses;
             return this;
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPromotionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPromotionRepository.java
@@ -32,6 +32,7 @@ import java.sql.PreparedStatement;
 import java.sql.Types;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -96,8 +97,8 @@ public class JdbcPromotionRepository extends JdbcAbstractCrudRepository<Promotio
                         .append(" ) ");
                 }
 
-                if (criteria.getStatus() != null) {
-                    query.append(" and status = ?");
+                if (!isEmpty(criteria.getStatuses())) {
+                    query.append(" and status in ( ").append(getOrm().buildInClause(criteria.getStatuses())).append(" ) ");
                 }
 
                 if (criteria.getTargetApiExists() != null) {
@@ -124,8 +125,9 @@ public class JdbcPromotionRepository extends JdbcAbstractCrudRepository<Promotio
                                 idx = getOrm().setArguments(ps, criteria.getTargetEnvCockpitIds(), idx);
                             }
 
-                            if (criteria.getStatus() != null) {
-                                ps.setString(idx++, criteria.getStatus().name());
+                            if (!isEmpty(criteria.getStatuses())) {
+                                List<String> statusesNames = criteria.getStatuses().stream().map(Enum::name).collect(Collectors.toList());
+                                idx = getOrm().setArguments(ps, statusesNames, idx);
                             }
 
                             if (!isEmpty(criteria.getApiId())) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.PromotionMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -56,8 +57,9 @@ public class PromotionMongoRepositoryImpl implements PromotionMongoRepositoryCus
                 query.addCriteria(where("targetEnvCockpitId").in(criteria.getTargetEnvCockpitIds()));
             }
 
-            if (criteria.getStatus() != null) {
-                query.addCriteria(where("status").is(criteria.getStatus()));
+            if (criteria.getStatuses() != null) {
+                List<String> statusNames = criteria.getStatuses().stream().map(Enum::name).collect(Collectors.toList());
+                query.addCriteria(where("status").in(statusNames));
             }
 
             if (criteria.getTargetApiExists() != null) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PromotionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PromotionRepositoryTest.java
@@ -165,8 +165,8 @@ public class PromotionRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
-    public void shouldSearchWithCriteriaStatus() throws Exception {
-        final PromotionCriteria criteria = new PromotionCriteria.Builder().status(PromotionStatus.TO_BE_VALIDATED).build();
+    public void shouldSearchWithCriteriaStatuses() throws Exception {
+        final PromotionCriteria criteria = new PromotionCriteria.Builder().statuses(List.of(PromotionStatus.TO_BE_VALIDATED)).build();
         final List<Promotion> promotions = promotionRepository
             .search(criteria, null, new PageableBuilder().pageNumber(0).pageSize(Integer.MAX_VALUE).build())
             .getContent();
@@ -177,8 +177,24 @@ public class PromotionRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldSearchWithCriteriaStatusesMultipleValues() throws Exception {
+        final PromotionCriteria criteria = new PromotionCriteria.Builder()
+            .statuses(List.of(PromotionStatus.TO_BE_VALIDATED, PromotionStatus.CREATED))
+            .build();
+        final List<Promotion> promotions = promotionRepository
+            .search(criteria, null, new PageableBuilder().pageNumber(0).pageSize(Integer.MAX_VALUE).build())
+            .getContent();
+        assertNotNull(promotions);
+        assertEquals("Invalid promotions numbers in search", 4, promotions.size());
+        assertEquals("promotion#1", promotions.get(0).getId());
+        assertEquals("promotion#to-delete", promotions.get(1).getId());
+        assertEquals("promotion#to_be_validated_env_1", promotions.get(2).getId());
+        assertEquals("promotion#to_be_validated_env_2", promotions.get(3).getId());
+    }
+
+    @Test
     public void shouldSearchWithCriteriaStatusSortByCreatedAtDesc() throws Exception {
-        final PromotionCriteria criteria = new PromotionCriteria.Builder().status(PromotionStatus.TO_BE_VALIDATED).build();
+        final PromotionCriteria criteria = new PromotionCriteria.Builder().statuses(List.of(PromotionStatus.TO_BE_VALIDATED)).build();
         final List<Promotion> promotions = promotionRepository
             .search(
                 criteria,
@@ -194,7 +210,7 @@ public class PromotionRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     public void shouldSearchWithCriteriaStatusPaginated() throws Exception {
-        final PromotionCriteria criteria = new PromotionCriteria.Builder().status(PromotionStatus.TO_BE_VALIDATED).build();
+        final PromotionCriteria criteria = new PromotionCriteria.Builder().statuses(List.of(PromotionStatus.TO_BE_VALIDATED)).build();
         final List<Promotion> promotions = promotionRepository
             .search(
                 criteria,

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PromotionRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PromotionRepositoryMock.java
@@ -71,7 +71,7 @@ public class PromotionRepositoryMock extends AbstractRepositoryMock<PromotionRep
         // shouldSearchWithEmptyCriteria
         when(
             repository.search(
-                argThat(o -> o != null && o.getTargetEnvCockpitIds() == null && o.getStatus() == null),
+                argThat(o -> o != null && o.getTargetEnvCockpitIds() == null && o.getStatuses() == null),
                 nullable(Sortable.class),
                 any()
             )
@@ -86,7 +86,7 @@ public class PromotionRepositoryMock extends AbstractRepositoryMock<PromotionRep
                         o != null &&
                         o.getTargetEnvCockpitIds() != null &&
                         o.getTargetEnvCockpitIds().contains("env#cockpit-1") &&
-                        o.getStatus() == null
+                        o.getStatuses() == null
                 ),
                 nullable(Sortable.class),
                 any()
@@ -94,21 +94,32 @@ public class PromotionRepositoryMock extends AbstractRepositoryMock<PromotionRep
         )
             .thenReturn(new Page<>(asList(promotionToBeValidatedEnv1), 0, 0, 1));
 
-        // shouldSearchWithCriteriaStatus
+        // shouldSearchWithCriteriaStatuses
         when(
             repository.search(
                 argThat(
                     o ->
                         o != null &&
                         o.getTargetEnvCockpitIds() == null &&
-                        o.getStatus() != null &&
-                        o.getStatus().equals(PromotionStatus.TO_BE_VALIDATED)
+                        o.getStatuses() != null &&
+                        o.getStatuses().size() == 1 &&
+                        o.getStatuses().get(0).equals(PromotionStatus.TO_BE_VALIDATED)
                 ),
                 nullable(Sortable.class),
                 any()
             )
         )
             .thenReturn(new Page<>(asList(promotionToBeValidatedEnv1, promotionToBeValidatedEnv2), 0, 0, 2));
+
+        // shouldSearchWithCriteriaStatusesMultipleValues
+        when(
+            repository.search(
+                argThat(o -> o != null && o.getTargetEnvCockpitIds() == null && o.getStatuses() != null && o.getStatuses().size() == 2),
+                nullable(Sortable.class),
+                any()
+            )
+        )
+            .thenReturn(new Page<>(asList(promotion, promotionToDelete, promotionToBeValidatedEnv1, promotionToBeValidatedEnv2), 0, 0, 2));
 
         // shouldSearchWithCriteriaStatusSortByCreatedAtDesc
         when(
@@ -117,8 +128,9 @@ public class PromotionRepositoryMock extends AbstractRepositoryMock<PromotionRep
                     o ->
                         o != null &&
                         o.getTargetEnvCockpitIds() == null &&
-                        o.getStatus() != null &&
-                        o.getStatus().equals(PromotionStatus.TO_BE_VALIDATED)
+                        o.getStatuses() != null &&
+                        o.getStatuses().size() == 1 &&
+                        o.getStatuses().get(0).equals(PromotionStatus.TO_BE_VALIDATED)
                 ),
                 argThat(sortable -> sortable != null && sortable.field().equals("created_at") && sortable.order().equals(Order.DESC)),
                 argThat(pageable -> pageable != null && pageable.pageSize() == (Integer.MAX_VALUE))
@@ -133,8 +145,9 @@ public class PromotionRepositoryMock extends AbstractRepositoryMock<PromotionRep
                     o ->
                         o != null &&
                         o.getTargetEnvCockpitIds() == null &&
-                        o.getStatus() != null &&
-                        o.getStatus().equals(PromotionStatus.TO_BE_VALIDATED)
+                        o.getStatuses() != null &&
+                        o.getStatuses().size() == 1 &&
+                        o.getStatuses().get(0).equals(PromotionStatus.TO_BE_VALIDATED)
                 ),
                 argThat(sortable -> sortable != null && sortable.field().equals("created_at") && sortable.order().equals(Order.DESC)),
                 argThat(pageable -> pageable != null && pageable.pageSize() == 1)
@@ -149,7 +162,7 @@ public class PromotionRepositoryMock extends AbstractRepositoryMock<PromotionRep
                     o ->
                         o != null &&
                         o.getTargetEnvCockpitIds() == null &&
-                        o.getStatus() == null &&
+                        o.getStatuses() == null &&
                         o.getApiId() != null &&
                         o.getApiId().equals("api#1")
                 ),
@@ -166,7 +179,7 @@ public class PromotionRepositoryMock extends AbstractRepositoryMock<PromotionRep
                     o ->
                         o != null &&
                         o.getTargetEnvCockpitIds() == null &&
-                        o.getStatus() == null &&
+                        o.getStatuses() == null &&
                         o.getTargetApiExists() != null &&
                         o.getTargetApiExists().equals(true)
                 ),


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5746

**Description**

Add support for multiple statuses search in PromotionRepository

BREAKING CHANGES: Instead of setting a status in  `PromotionCriteria.status` you need to set a list of a single status in `PromotionCriteria.statuses`