### PR TITLE
chore: add docker-compose for quick APIM setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ node_modules
 
 # used in makefile as working directory
 .working/
+# used
+.logs/
 # -- Cicd : Git ignore the [.circleci/**/*] which contains
 # files which do not need to be commited (password to artifactory)
 #.circleci/**/*

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------------------
+#                              CUSTOM FUNCTION
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+#                                ENV VARIABLE
+# -----------------------------------------------------------------------------
+
+# API Management version for docker images pulling
+APIM_VERSION:=nightly
+
+# Retrieve current file name, must be done before doing "include .env" ...
+makefile := $(MAKEFILE_LIST)
+# Projects list (extracted from .env file, looking for every XXX_REPOSITORY variables)
+
+# -----------------------------------------------------------------------------
+#                                 Main targets
+# -----------------------------------------------------------------------------
+
+help: ## Print this message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(makefile) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+
+http-bridge: ## Run API Management with two gateways as Bridge HTTP Server and Bridge HTTP Client. Will run by default with 'nightly' images, but you can pass version with: make http-bridge APIM_VERSION={version}
+	cd ./quick-setup/gateway-http-bridge-repository && docker-compose down -v && docker-compose pull && docker-compose up
+
+.DEFAULT_GOAL := help
+.PHONY: http-bridge

--- a/docker/quick-setup/README.md
+++ b/docker/quick-setup/README.md
@@ -1,0 +1,3 @@
+# Quick APIM setup
+
+You will find here a collection of docker-compose to easily test _complex_ installations of APIM.

--- a/docker/quick-setup/gateway-http-bridge-repository/README.md
+++ b/docker/quick-setup/gateway-http-bridge-repository/README.md
@@ -1,0 +1,21 @@
+# Gateway with Bridge HTTP
+
+Here is a docker-compose to run APIM with two gateways:
+ - One as a **Bridge Server.** It can make calls to the database and expose HTTP endpoints to be able to call the database.
+ - One as a **Bridge Client.** It calls the Gateway Bridge Server through HTTP to fetch data.
+
+You can classically call your apis through your gateway, for example: `http://localhost:8082/myapi`.
+
+To test the **Bridge Server**, you can call, for example, `http://localhost:18092/_bridge/apis` to list all the apis.
+
+---
+**NOTE**
+For more information, please read this doc: https://docs.gravitee.io/apim/3.x/apim_installguide_hybrid_deployment.html#apim_gateway_http_bridge_server
+---
+
+## How to run ?
+
+`APIM_VERSION={APIM_VERSION} docker-compose up -d ` 
+
+To be sure to fetch last version of images, you can do
+`export APIM_VERSION={APIM_VERSION} && docker-compose down -v && docker-compose pull && docker-compose up`

--- a/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
@@ -1,0 +1,164 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '3.5'
+
+networks:
+  frontend:
+    name: frontend
+  storage:
+    name: storage
+
+volumes:
+  data-elasticsearch:
+  data-mongo:
+
+services:
+  mongodb:
+    image: mongo:${MONGODB_VERSION:-3.6}
+    container_name: gio_apim_mongodb
+    restart: always
+    volumes:
+      - data-mongo:/data/db
+      - ./.logs/apim-mongodb:/var/log/mongodb
+    networks:
+      - storage
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    container_name: gio_apim_elasticsearch
+    restart: always
+    volumes:
+      - data-elasticsearch:/usr/share/elasticsearch/data
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=0.0.0.0
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - cluster.name=elasticsearch
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile: 65536
+    networks:
+      - storage
+
+  gateway_server:
+    image: graviteeio/apim-gateway:${APIM_VERSION:-3}
+    container_name: gio_apim_gateway_server
+    restart: always
+    ports:
+      - "18092:18092"
+    depends_on:
+      - mongodb
+    volumes:
+      - ./.logs/apim-gateway-server:/opt/graviteeio-gateway/logs
+    environment:
+      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_reporters_elasticsearch_enabled=false
+      - gravitee_services_bridge_http_enabled=true
+      - gravitee_services_bridge_http_port=18092
+      - gravitee_services_bridge_http_host=0.0.0.0
+      - gravitee_services_bridge_http_authentication_type=basic
+      - gravitee_services_bridge_http_authentication_users_admin=adminadmin
+      - gravitee_services_bridge_http_secured=false
+      - gravitee_services_bridge_http_ssl_clientAuth=false
+    networks:
+      - storage
+      - frontend
+
+  gateway_client:
+    image: graviteeio/apim-gateway:${APIM_VERSION:-3}
+    container_name: gio_apim_gateway_client
+    restart: always
+    ports:
+      - "8082:8082"
+    links:
+      # Workaround used because of call to URI.create(uri) in WebClientFactory. If host contains "_", then host is null and the connection cannot be done.
+      - "gateway_server:gateway-server"
+    depends_on:
+      - elasticsearch
+      - gateway_server
+    volumes:
+      - ./.logs/apim-gateway-client:/opt/graviteeio-gateway/logs
+    environment:
+      - gravitee_management_type=http
+      - gravitee_management_http_url=http://gateway-server:18092
+      - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+      - gravitee_ds_mongodb_host=mongodb
+      - gravitee_reporters_elasticsearch_enabled=true
+      - gravitee_management_http_authentication_basic_username=admin
+      - gravitee_management_http_authentication_basic_password=adminadmin
+      - gravitee_management_http_ssl_verifyHostName=false
+    networks:
+      - storage
+      - frontend
+
+  management_api:
+    image: graviteeio/apim-management-api:${APIM_VERSION:-3}
+    container_name: gio_apim_management_api
+    restart: always
+    ports:
+      - "8083:8083"
+    links:
+      - mongodb
+      - elasticsearch
+    depends_on:
+      - mongodb
+      - elasticsearch
+    volumes:
+      - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
+    environment:
+      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
+    networks:
+      - storage
+      - frontend
+
+  management_ui:
+    image: graviteeio/apim-management-ui:${APIM_VERSION:-3}
+    container_name: gio_apim_management_ui
+    restart: always
+    ports:
+      - "8084:8080"
+    depends_on:
+      - management_api
+    environment:
+      - MGMT_API_URL=http://localhost:8083/management/organizations/DEFAULT/environments/DEFAULT/
+    volumes:
+      - ./.logs/apim-management-ui:/var/log/nginx
+    networks:
+      - frontend
+
+  portal_ui:
+    image: graviteeio/apim-portal-ui:${APIM_VERSION:-3}
+    container_name: gio_apim_portal_ui
+    restart: always
+    ports:
+      - "8085:8080"
+    depends_on:
+      - management_api
+    environment:
+      - PORTAL_API_URL=http://localhost:8083/portal/environments/DEFAULT
+    volumes:
+      - ./.logs/apim-portal-ui:/var/log/nginx
+    networks:
+      - frontend


### PR DESCRIPTION
first docker-compose allow to have an APIM with two gateways as Bridge HTTP Server and Client