### PR TITLE
fix: change folder name for management API

### DIFF
--- a/gravitee-apim-management-api/docker/Dockerfile
+++ b/gravitee-apim-management-api/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apk update \
 	&& wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-full-${GRAVITEEIO_VERSION}.zip --no-check-certificate -P /tmp \
     && unzip /tmp/graviteeio-full-${GRAVITEEIO_VERSION}.zip -d /tmp/ \
 	&& apk del zip unzip netcat-openbsd wget \
-    && mv /tmp/graviteeio-full-${GRAVITEEIO_VERSION}/graviteeio-rest-api* ${GRAVITEEIO_HOME} \
+    && mv /tmp/graviteeio-full-${GRAVITEEIO_VERSION}/graviteeio-apim-management-api* ${GRAVITEEIO_HOME} \
     && rm -rf /tmp/* \
 	&& chgrp -R 0 ${GRAVITEEIO_HOME} \
     && chmod -R g=u ${GRAVITEEIO_HOME}

--- a/gravitee-apim-management-api/docker/Dockerfile-dev
+++ b/gravitee-apim-management-api/docker/Dockerfile-dev
@@ -23,8 +23,8 @@ RUN apk add --update zip unzip
 
 RUN echo $GRAVITEEAPIM_VERSION
 
-ADD ./gravitee-rest-api-standalone-${GRAVITEEAPIM_VERSION}.zip /tmp/
-RUN unzip /tmp/gravitee-rest-api-standalone-${GRAVITEEAPIM_VERSION}.zip -d /tmp/
+ADD ./gravitee-apim-management-api-standalone-${GRAVITEEAPIM_VERSION}.zip /tmp/
+RUN unzip /tmp/gravitee-apim-management-api-standalone-${GRAVITEEAPIM_VERSION}.zip -d /tmp/
 
 FROM adoptopenjdk/openjdk11:jre-11.0.10_9-alpine
 MAINTAINER Gravitee Team <http://gravitee.io>
@@ -33,7 +33,7 @@ RUN apk add --update curl
 
 ENV GRAVITEEAPIM_HOME /opt/graviteeio-management-api
 
-COPY --from=build-env /tmp/gravitee-rest-api-standalone-* ${GRAVITEEAPIM_HOME}/
+COPY --from=build-env /tmp/gravitee-apim-management-api-standalone-* ${GRAVITEEAPIM_HOME}/
 
 RUN chgrp -R 0 ${GRAVITEEAPIM_HOME} && \
     chmod -R g=u ${GRAVITEEAPIM_HOME}


### PR DESCRIPTION
**Description**

Change the folder name of Management API distribution within the full zip so the docker image can be built