### PR TITLE
Allow maven parallel build

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.PortalNotificationDefaultReferenceId;
@@ -198,7 +199,7 @@ public class EnvironmentConfigurationResource {
     @GET
     @Path("spel/grammar")
     @Produces(MediaType.APPLICATION_JSON)
-    public JSONObject getGrammar() {
+    public JsonNode getGrammar() {
         return spelService.getGrammar();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
@@ -34,7 +34,7 @@
 	<name>Gravitee.io APIM - Management API - Portal - Rest API</name>
 
 	<properties>
-		<openapi-generator.version>4.1.1</openapi-generator.version>
+		<openapi-generator.version>4.3.1</openapi-generator.version>
         <openapi.modelPackage>io.gravitee.rest.api.portal.rest.model</openapi.modelPackage>
 	</properties>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -51,6 +51,6 @@ public class ConfigurationMapperTest {
         mapper.setSerializationInclusion(Include.NON_NULL);
         mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
         String configurationAsJSON = mapper.writeValueAsString(configuration);
-        assertEquals(expected.trim(), configurationAsJSON.trim());
+        assertEquals(mapper.readTree(expected), mapper.readTree(configurationAsJSON));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/spel/SpelService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/configuration/spel/SpelService.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.rest.api.service.configuration.spel;
 
-import net.minidev.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface SpelService {
-    JSONObject getGrammar();
+    JsonNode getGrammar();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SpelServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SpelServiceTest.java
@@ -15,21 +15,16 @@
  */
 package io.gravitee.rest.api.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import io.gravitee.el.spel.context.SecuredMethodResolver;
-import io.gravitee.el.spel.context.SecuredResolver;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.rest.api.service.configuration.spel.SpelService;
 import io.gravitee.rest.api.service.impl.configuration.spel.SpelServiceImpl;
-import java.lang.reflect.Method;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -39,23 +34,18 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SpelServiceTest {
 
-    @InjectMocks
-    private SpelService spelService = new SpelServiceImpl();
+    private final ObjectMapper objectMapper = new GraviteeMapper();
 
-    @Mock
-    SecuredMethodResolver securedMethodResolver = new SecuredMethodResolver();
-
-    @Before
-    public void init() {
-        when(securedMethodResolver.getMethods(any())).thenReturn(new Method[] {});
-    }
+    private final SpelService spelService = new SpelServiceImpl(objectMapper);
 
     @Test
-    public void shouldGetGrammar() {
-        assertNotNull(spelService.getGrammar());
-        assertEquals(
-            "{\"request\":{\"headers\":{\"_type\":\"HttpHeaders\"},\"method\":{\"_type\":\"String\"},\"scheme\":{\"_type\":\"String\"},\"pathParams\":{\"_type\":\"MultiValueMap\"},\"pathInfos\":{\"_type\":\"String[]\"},\"contextPath\":{\"_type\":\"String\"},\"params\":{\"_type\":\"MultiValueMap\"},\"uri\":{\"_type\":\"String\"},\"version\":{\"_type\":\"String\"},\"content\":{\"_type\":\"String\"},\"transactionId\":{\"_type\":\"String\"},\"path\":{\"_type\":\"String\"},\"localAddress\":{\"_type\":\"String\"},\"paths\":{\"_type\":\"String[]\"},\"id\":{\"_type\":\"String\"},\"pathInfo\":{\"_type\":\"String\"},\"remoteAddress\":{\"_type\":\"String\"},\"timestamp\":{\"_type\":\"long\"}},\"endpoints\":{\"_type\":\"String[]\"},\"response\":{\"headers\":{\"_type\":\"HttpHeaders\"},\"content\":{\"_type\":\"String\"},\"status\":{\"_type\":\"int\"}},\"context\":{\"attributes\":{\"context-path\":{\"_type\":\"String\"},\"application\":{\"_type\":\"String\"},\"api-key\":{\"_type\":\"String\"},\"user-id\":{\"_type\":\"String\"},\"api\":{\"_type\":\"String\"},\"plan\":{\"_type\":\"String\"},\"resolved-path\":{\"_type\":\"String\"}}},\"_enums\":{\"HttpHeaders\":[\"Accept\",\"Accept-Charset\",\"Accept-Encoding\",\"Accept-Language\",\"Accept-Ranges\",\"Access-Control-Allow-Credentials\",\"Access-Control-Allow-Headers\",\"Access-Control-Allow-Methods\",\"Access-Control-Allow-Origin\",\"Access-Control-Expose-Headers\",\"Access-Control-Max-Age\",\"Access-Control-Request-Headers\",\"Access-Control-Request-Method\",\"Age\",\"Allow\",\"Authorization\",\"Cache-Control\",\"Connection\",\"Content-Disposition\",\"Content-Encoding\",\"Content-ID\",\"Content-Language\",\"Content-Length\",\"Content-Location\",\"Content-MD5\",\"Content-Range\",\"Content-Type\",\"Cookie\",\"Date\",\"ETag\",\"Expires\",\"Expect\",\"Forwarded\",\"From\",\"Host\",\"If-Match\",\"If-Modified-Since\",\"If-None-Match\",\"If-Unmodified-Since\",\"Keep-Alive\",\"Last-Modified\",\"Location\",\"Link\",\"Max-Forwards\",\"MIME-Version\",\"Origin\",\"Pragma\",\"Proxy-Authenticate\",\"Proxy-Authorization\",\"Proxy-Connection\",\"Range\",\"Referer\",\"Retry-After\",\"Server\",\"Set-Cookie\",\"Set-Cookie2\",\"TE\",\"Trailer\",\"Transfer-Encoding\",\"Upgrade\",\"User-Agent\",\"Vary\",\"Via\",\"Warning\",\"WWW-Authenticate\",\"X-Forwarded-For\",\"X-Forwarded-Proto\",\"X-Forwarded-Server\",\"X-Forwarded-Host\"]},\"_types\":{\"HttpHeaders\":{\"methods\":[]},\"Set\":{\"methods\":[]},\"String\":{\"methods\":[]},\"String[]\":{\"methods\":[]},\"Math\":{\"methods\":[]},\"Integer\":{\"methods\":[]},\"Long\":{\"methods\":[]},\"Collection\":{\"methods\":[]},\"Object\":{\"methods\":[]},\"List\":{\"methods\":[]},\"Boolean\":{\"methods\":[]},\"Map\":{\"methods\":[]},\"MultiValueMap\":{\"methods\":[]}},\"properties\":{\"_type\":\"String[]\"},\"dictionaries\":{\"_type\":\"String[]\"}}",
-            spelService.getGrammar().toJSONString()
-        );
+    public void shouldGetGrammar() throws JsonProcessingException {
+        final JsonNode grammar = spelService.getGrammar();
+        assertThat(grammar).isNotNull();
+
+        String expectedJson =
+            "{\"request\":{\"headers\":{\"_type\":\"HttpHeaders\"},\"method\":{\"_type\":\"String\"},\"scheme\":{\"_type\":\"String\"},\"pathParams\":{\"_type\":\"MultiValueMap\"},\"pathInfos\":{\"_type\":\"String[]\"},\"contextPath\":{\"_type\":\"String\"},\"params\":{\"_type\":\"MultiValueMap\"},\"uri\":{\"_type\":\"String\"},\"version\":{\"_type\":\"String\"},\"content\":{\"_type\":\"String\"},\"transactionId\":{\"_type\":\"String\"},\"path\":{\"_type\":\"String\"},\"localAddress\":{\"_type\":\"String\"},\"paths\":{\"_type\":\"String[]\"},\"id\":{\"_type\":\"String\"},\"pathInfo\":{\"_type\":\"String\"},\"remoteAddress\":{\"_type\":\"String\"},\"timestamp\":{\"_type\":\"long\"}},\"endpoints\":{\"_type\":\"String[]\"},\"response\":{\"headers\":{\"_type\":\"HttpHeaders\"},\"content\":{\"_type\":\"String\"},\"status\":{\"_type\":\"int\"}},\"context\":{\"attributes\":{\"context-path\":{\"_type\":\"String\"},\"application\":{\"_type\":\"String\"},\"api-key\":{\"_type\":\"String\"},\"user-id\":{\"_type\":\"String\"},\"api\":{\"_type\":\"String\"},\"plan\":{\"_type\":\"String\"},\"resolved-path\":{\"_type\":\"String\"}}},\"_enums\":{\"HttpHeaders\":[\"Accept\",\"Accept-Charset\",\"Accept-Encoding\",\"Accept-Language\",\"Accept-Ranges\",\"Access-Control-Allow-Credentials\",\"Access-Control-Allow-Headers\",\"Access-Control-Allow-Methods\",\"Access-Control-Allow-Origin\",\"Access-Control-Expose-Headers\",\"Access-Control-Max-Age\",\"Access-Control-Request-Headers\",\"Access-Control-Request-Method\",\"Age\",\"Allow\",\"Authorization\",\"Cache-Control\",\"Connection\",\"Content-Disposition\",\"Content-Encoding\",\"Content-ID\",\"Content-Language\",\"Content-Length\",\"Content-Location\",\"Content-MD5\",\"Content-Range\",\"Content-Type\",\"Cookie\",\"Date\",\"ETag\",\"Expires\",\"Expect\",\"Forwarded\",\"From\",\"Host\",\"If-Match\",\"If-Modified-Since\",\"If-None-Match\",\"If-Unmodified-Since\",\"Keep-Alive\",\"Last-Modified\",\"Location\",\"Link\",\"Max-Forwards\",\"MIME-Version\",\"Origin\",\"Pragma\",\"Proxy-Authenticate\",\"Proxy-Authorization\",\"Proxy-Connection\",\"Range\",\"Referer\",\"Retry-After\",\"Server\",\"Set-Cookie\",\"Set-Cookie2\",\"TE\",\"Trailer\",\"Transfer-Encoding\",\"Upgrade\",\"User-Agent\",\"Vary\",\"Via\",\"Warning\",\"WWW-Authenticate\",\"X-Forwarded-For\",\"X-Forwarded-Proto\",\"X-Forwarded-Server\",\"X-Forwarded-Host\"]},\"_types\":{\"HttpHeaders\":{\"methods\":[]},\"Set\":{\"methods\":[]},\"String\":{\"methods\":[]},\"String[]\":{\"methods\":[]},\"Math\":{\"methods\":[]},\"Integer\":{\"methods\":[]},\"Long\":{\"methods\":[]},\"Collection\":{\"methods\":[]},\"Object\":{\"methods\":[]},\"List\":{\"methods\":[]},\"Boolean\":{\"methods\":[]},\"Map\":{\"methods\":[]},\"MultiValueMap\":{\"methods\":[]}},\"properties\":{\"_type\":\"String[]\"},\"dictionaries\":{\"_type\":\"String[]\"}}";
+
+        assertThat(grammar).isEqualTo(objectMapper.readTree(expectedJson));
     }
 }


### PR DESCRIPTION
**Description**

The goal of this PR is to allow parallel build with maven to improve build time.
Two problems prevented us to do this:
1. For an unknown reason, parallel build fails if we use json-smart dependency to manipulate JsonNode
2. The openapigenerator-maven-plugin is not thread safe

This PR:
1. replaces json-smart usage with jackson
2. bump openapi-generatpr-maven-plugin to 4.3.1 (higher versions produce classes that don't compile 😢 )

