### PR TITLE
feat(documentation): add AsyncApi page type

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/FetchablePageEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/FetchablePageEntity.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import java.util.Map;
+
+/**
+ * A page that can be fetched from an external source.
+ *
+ * @author GraviteeSource Team
+ */
+public abstract class FetchablePageEntity {
+
+    private String content;
+
+    private PageSourceEntity source;
+
+    private Map<String, String> metadata;
+
+    private Boolean useAutoFetch; // use Boolean to avoid default value of primitive type
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public PageSourceEntity getSource() {
+        return source;
+    }
+
+    public void setSource(PageSourceEntity source) {
+        this.source = source;
+    }
+
+    public Map<String, String> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+    }
+
+    public Boolean getUseAutoFetch() {
+        return useAutoFetch;
+    }
+
+    public void setUseAutoFetch(Boolean useAutoFetch) {
+        this.useAutoFetch = useAutoFetch;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewPageEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewPageEntity.java
@@ -27,7 +27,7 @@ import javax.validation.constraints.Size;
  * @author Guillaume GILLON
  * @author GraviteeSource Team
  */
-public class NewPageEntity {
+public class NewPageEntity extends FetchablePageEntity {
 
     @NotNull
     @Size(min = 1)
@@ -35,8 +35,6 @@ public class NewPageEntity {
 
     @NotNull
     private PageType type;
-
-    private String content;
 
     private int order;
 
@@ -78,14 +76,6 @@ public class NewPageEntity {
 
     public void setType(PageType type) {
         this.type = type;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public void setContent(String content) {
-        this.content = content;
     }
 
     public int getOrder() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdatePageEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdatePageEntity.java
@@ -26,13 +26,11 @@ import javax.validation.constraints.Size;
  * @author Titouan COMPIEGNE
  * @author Guillaume GILLON
  */
-public class UpdatePageEntity {
+public class UpdatePageEntity extends FetchablePageEntity {
 
     @NotNull
     @Size(min = 1)
     private String name;
-
-    private String content;
 
     private String lastContributor;
 
@@ -66,14 +64,6 @@ public class UpdatePageEntity {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public String getContent() {
-        return content;
-    }
-
-    public void setContent(String content) {
-        this.content = content;
     }
 
     public String getLastContributor() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PageTypeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PageTypeTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import static io.gravitee.rest.api.model.PageType.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PageTypeTest {
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_swagger_called_with_valid_swagger_json_content() {
+        String pageExtension = "json";
+        String pageContent = "{\"swagger\":\"2.0\",\"info\":";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertSame(SWAGGER, type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_null_called_with_invalid_swagger_json_content() {
+        String pageExtension = "json";
+        String pageContent = "{\"swaXXXger\":\"2.0\",\"info\":";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertNull(type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_swagger_called_with_valid_swagger_yml_content() {
+        String pageExtension = "yml";
+        String pageContent = "swagger: 2.0\ninfo:";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertSame(SWAGGER, type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_swagger_called_with_valid_openapi_yml_content() {
+        String pageExtension = "yml";
+        String pageContent = "openapi: 2.0\ninfo:";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertSame(SWAGGER, type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_null_called_with_invalid_swagger_yml_content() {
+        String pageExtension = "yml";
+        String pageContent = "swagXXXger: 2.0\ninfo:";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertNull(type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_asyncapi_called_with_valid_asyncapi_json_content() {
+        String pageExtension = "json";
+        String pageContent = "{\"asyncapi\":\"2.0\",\"info\":";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertSame(ASYNCAPI, type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_null_called_with_invalid_asyncapi_json_content() {
+        String pageExtension = "json";
+        String pageContent = "{\"asyXXapi\":\"2.0\",\"info\":";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertNull(type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_asyncapi_called_with_valid_asyncapi_yml_content() {
+        String pageExtension = "yml";
+        String pageContent = "asyncapi: 2.0\ninfo:";
+        pageContent = "asyncapi: 2.0\ninfo";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertSame(ASYNCAPI, type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_null_called_with_invalid_asyncapi_yml_content() {
+        String pageExtension = "yml";
+        String pageContent = "asyXXXpi: 2.0\ninfo:";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertNull(type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_asciidoc_called_with_asciidoc_extension() {
+        String pageExtension = "adoc";
+        String pageContent = "This is an asciidoc document";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertSame(ASCIIDOC, type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_markdown_called_with_markdown_extension() {
+        String pageExtension = "md";
+        String pageContent = "This is a markdown document";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertSame(MARKDOWN, type);
+    }
+
+    @Test
+    public void fromPageExtensionAndContent_should_return_null_called_with_unknown_extension() {
+        String pageExtension = "tzr";
+        String pageContent = "This is an unknown format document";
+
+        PageType type = PageType.fromPageExtensionAndContent(pageExtension, pageContent);
+
+        assertNull(type);
+    }
+
+    @Test
+    public void matchesExtension_should_return_true_when_it_matches() {
+        assertTrue(MARKDOWN.matchesExtension("Md"));
+    }
+
+    @Test
+    public void matchesExtension_should_return_false_when_it_doesnt_matches() {
+        assertFalse(MARKDOWN.matchesExtension("mxd"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -3544,6 +3544,7 @@ components:
           type: string
           enum:
             - ASCIIDOC
+            - ASYNCAPI
             - SWAGGER
             - MARKDOWN
             - FOLDER

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_CreateTest.java
@@ -462,7 +462,6 @@ public class PageService_CreateTest {
 
         final String name = "PAGE_NAME";
 
-        when(newPage.getName()).thenReturn(name);
         when(newPage.getSource()).thenReturn(pageSource);
         when(newPage.getVisibility()).thenReturn(Visibility.PUBLIC);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportAutFetchDescriptorMockFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportAutFetchDescriptorMockFetcher.java
@@ -69,9 +69,9 @@ public class PageService_ImportAutFetchDescriptorMockFetcher implements FilesFet
         "                \"name\": \"ma deuxieme page\"" +
         "            }," +
         "            {" +
-        "                \"src\": \"/docs/swagger/swagger.json\"," +
+        "                \"src\": \"/docs/asciidoc/asciidoc.adoc\"," +
         "                \"dest\": \"/technical\"," +
-        "                \"name\": \"Swagger\"" +
+        "                \"name\": \"AsciiDoc\"" +
         "            }," +
         "            {" +
         "                \"src\": \"/docs/swagger/readme.md\"," +

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorMockFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorMockFetcher.java
@@ -68,9 +68,9 @@ public class PageService_ImportDescriptorMockFetcher implements FilesFetcher {
         "                \"name\": \"ma deuxieme page\"" +
         "            }," +
         "            {" +
-        "                \"src\": \"/docs/swagger/swagger.json\"," +
+        "                \"src\": \"/docs/asciidoc/asciidoc.adoc\"," +
         "                \"dest\": \"/technical\"," +
-        "                \"name\": \"Swagger\"" +
+        "                \"name\": \"Asciidoc\"" +
         "            }," +
         "            {" +
         "                \"src\": \"/docs/swagger/readme.md\"," +

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
@@ -131,6 +131,6 @@ public class PageService_ImportDescriptorTest {
 
         assertNotNull(pageEntities);
         assertEquals(8, pageEntities.size());
-        verify(pageRevisionService, times(6)).create(any());
+        verify(pageRevisionService, times(5)).create(any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryMockFetcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryMockFetcher.java
@@ -45,9 +45,9 @@ public class PageService_ImportDirectoryMockFetcher implements FilesFetcher {
     public String[] files() throws FetcherException {
         return new String[] {
             "/src/doc/m1.md",
-            "/swagger.json",
+            "/asciidoc.adoc",
             "/src/doc/sub.m11.md",
-            "/src/doc/m2.yaml",
+            "/src/doc/asciidoc2.adoc",
             "/src/folder.with.dot/m2.MD",
             "/src/noFolder",
             "/src/noFolder2/",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
@@ -188,8 +188,8 @@ public class PageService_ImportDirectoryTest {
             .create(
                 argThat(
                     pageToCreate ->
-                        "swagger".equals(pageToCreate.getName()) &&
-                        "SWAGGER".equals(pageToCreate.getType()) &&
+                        "asciidoc".equals(pageToCreate.getName()) &&
+                        "ASCIIDOC".equals(pageToCreate.getType()) &&
                         null == pageToCreate.getParentId()
                 )
             );
@@ -210,8 +210,8 @@ public class PageService_ImportDirectoryTest {
             .create(
                 argThat(
                     pageToCreate ->
-                        "m2".equals(pageToCreate.getName()) &&
-                        "SWAGGER".equals(pageToCreate.getType()) &&
+                        "asciidoc2".equals(pageToCreate.getName()) &&
+                        "ASCIIDOC".equals(pageToCreate.getType()) &&
                         null != pageToCreate.getParentId()
                 )
             );
@@ -226,6 +226,6 @@ public class PageService_ImportDirectoryTest {
                 )
             );
 
-        verify(pageRevisionService, times(5)).create(any());
+        verify(pageRevisionService, times(3)).create(any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageServiceImplTests.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageServiceImplTests.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PageServiceImplTests {
+
+    private PageServiceImpl pageService = new PageServiceImpl();
+
+    @Test
+    public void getParentPathFromFilePath_should_return_correct_path() {
+        String parentPath = pageService.getParentPathFromFilePath("/folder1/folder.2/folder3/file.txt");
+        assertEquals("/folder1/folder.2/folder3", parentPath);
+    }
+
+    @Test
+    public void getParentPathFromFilePath_with_filename_should_return_empty() {
+        String parentPath = pageService.getParentPathFromFilePath("file.txt");
+        assertEquals("", parentPath);
+    }
+
+    @Test
+    public void getParentPathFromFilePath_with_empty_path_should_return_slash() {
+        String parentPath = pageService.getParentPathFromFilePath("");
+        assertEquals("/", parentPath);
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5575

**Description**

Add AsyncApi page type.

It needs to rework the 'import' feature, as page type can't be defined anymore according to the file extension.
The file is fetched first, then its type is defined according to extension + content (which should match a given regexp).

Previously, pages were fetched from the source using the repository object (Page), just before the repository saving.
That doesn't fit anymore, cause we do this fetch at start of process, so, can't use the repository object.
The fetch process is now done with a business object which extends FetchablePageEntity.
