### PR TITLE
fix(documentation): fix sensitive data merging between fetchers

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -2345,7 +2345,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                 try {
                     field.set(fetcherConfiguration, SENSITIVE_DATA_REPLACEMENT);
                 } catch (IllegalAccessException e) {
-                    e.printStackTrace();
+                    logger.error("Error while removing fetcher sensitive data", e);
                 }
                 field.setAccessible(accessible);
             }
@@ -2367,8 +2367,8 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                         updated = true;
                         field.set(updatedFetcherConfiguration, field.get(originalFetcherConfiguration));
                     }
-                } catch (IllegalAccessException e) {
-                    e.printStackTrace();
+                } catch (IllegalAccessException | IllegalArgumentException e) {
+                    logger.error("Error while merging original fetcher sensitive data to new fetcher", e);
                 }
                 field.setAccessible(accessible);
             }


### PR DESCRIPTION
**Issue**
- Go on a document attached to an external source which has sensitive data (for example a GitHub source)
- In the "external source" tab, change the source to one of another type
- Save
---> An IllegalArgumentException is thrown and shown as the process is trying to set, by reflection, a field to different class.

**Fix**
Safer way to fix was to catch IllegalArgumentException (avoids an inaccurate 'class equals' check).
