### PR TITLE
Remove useless catch in API debug handler

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -47,7 +47,6 @@ import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.promotion.PromotionService;
 import io.swagger.annotations.*;
 import java.io.ByteArrayOutputStream;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -342,12 +341,8 @@ public class ApiResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response debugAPI(@ApiParam(name = "request") @Valid final DebugApiEntity debugApiEntity) {
-        try {
-            EventEntity apiEntity = debugApiService.debug(api, getAuthenticatedUser(), debugApiEntity);
-            return Response.ok(apiEntity).build();
-        } catch (Exception e) {
-            return Response.status(Status.INTERNAL_SERVER_ERROR).entity("JsonProcessingException " + e).build();
-        }
+        EventEntity apiEntity = debugApiService.debug(api, getAuthenticatedUser(), debugApiEntity);
+        return Response.ok(apiEntity).build();
     }
 
     @GET


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5901

**Description**

I don't know why a catch Exception was added there but it was messing with everything because all the domain exceptions were caught and convert to a non JSON compliant output.
