### PR TITLE
chore: add runtime library to add LatencyUtils

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly.xml
@@ -120,5 +120,16 @@
             <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
         </dependencySet>
+        <dependencySet>
+            <outputDirectory>/lib/ext</outputDirectory>
+            <unpack>false</unpack>
+            <excludes>
+                <exclude>io.gravitee.*:*:*</exclude>
+                <exclude>commons-logging:commons-logging:*</exclude>
+                <exclude>javax.mail:mailapi:*</exclude>
+            </excludes>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5996

**Description**

Since the migration of micrometer-registry-prometheus from 1.10 to 1.6.2, the LatencyUtils library scope has changed from `compile` to `runtime`
So we need to add runtime dependencies when building distribution.
