### PR TITLE
feat(encryptableProperties): encrypt API properties on API creation and update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PropertiesEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PropertiesEntity.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import static java.util.stream.Collectors.toList;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.Property;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PropertiesEntity {
+
+    @JsonProperty("properties")
+    private List<PropertyEntity> properties = new ArrayList<>();
+
+    public PropertiesEntity() {}
+
+    public PropertiesEntity(List<PropertyEntity> properties) {
+        this.properties = properties;
+    }
+
+    public PropertiesEntity(Properties properties) {
+        if (properties != null && properties.getProperties() != null) {
+            this.properties = properties.getProperties().stream().map(PropertyEntity::new).collect(toList());
+        }
+    }
+
+    public List<PropertyEntity> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(List<PropertyEntity> properties) {
+        this.properties = properties;
+    }
+
+    public Properties toDefinition() {
+        Properties definitionProperties = new Properties();
+        definitionProperties.setProperties(properties.stream().map(property -> (Property) property).collect(toList()));
+        return definitionProperties;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PropertyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PropertyEntity.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Property;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PropertyEntity extends Property {
+
+    @JsonProperty(value = "encryptable")
+    private boolean encryptable = false;
+
+    public PropertyEntity() {
+        super();
+    }
+
+    public PropertyEntity(String key, String value) {
+        super(key, value);
+    }
+
+    public PropertyEntity(String key, String value, boolean encryptable, boolean encrypted) {
+        super(key, value, encrypted);
+        this.encryptable = encryptable;
+    }
+
+    public PropertyEntity(Property property) {
+        super(property.getKey(), property.getValue(), property.isEncrypted());
+        this.dynamic = property.isDynamic();
+    }
+
+    public boolean isEncryptable() {
+        return encryptable;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
@@ -25,9 +25,8 @@ import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.definition.model.services.Services;
-import io.gravitee.rest.api.model.ApiMetadataEntity;
-import io.gravitee.rest.api.model.DeploymentRequired;
-import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.jackson.PropertiesEntityAsListDeserializer;
 import io.swagger.annotations.ApiModelProperty;
 import java.util.*;
 import javax.validation.constraints.NotEmpty;
@@ -79,7 +78,7 @@ public class UpdateApiEntity {
 
     @JsonProperty(value = "properties")
     @ApiModelProperty(value = "A dictionary (could be dynamic) of properties available in the API context.")
-    private io.gravitee.definition.model.Properties properties;
+    private PropertiesEntity properties;
 
     @NotNull
     @ApiModelProperty(value = "The visibility of the API regarding the portal.", example = "PUBLIC", allowableValues = "PUBLIC, PRIVATE")
@@ -198,23 +197,22 @@ public class UpdateApiEntity {
         this.services = services;
     }
 
-    public Properties getProperties() {
+    public PropertiesEntity getProperties() {
         return properties;
     }
 
-    public void setProperties(Properties properties) {
+    public void setProperties(PropertiesEntity properties) {
         this.properties = properties;
     }
 
     @JsonSetter("properties")
-    @JsonDeserialize(using = PropertiesAsListDeserializer.class)
-    public void setPropertyList(List<Property> properties) {
-        this.properties = new Properties();
-        this.properties.setProperties(properties);
+    @JsonDeserialize(using = PropertiesEntityAsListDeserializer.class)
+    public void setPropertyList(List<PropertyEntity> properties) {
+        this.properties = new PropertiesEntity(properties);
     }
 
     @JsonGetter("properties")
-    public List<Property> getPropertyList() {
+    public List<PropertyEntity> getPropertyList() {
         if (properties != null) {
             return properties.getProperties();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/jackson/PropertiesEntityAsListDeserializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/jackson/PropertiesEntityAsListDeserializer.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
+import io.gravitee.rest.api.model.PropertyEntity;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PropertiesEntityAsListDeserializer extends StdScalarDeserializer<List<PropertyEntity>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesEntityAsListDeserializer.class);
+
+    public PropertiesEntityAsListDeserializer() {
+        super(List.class);
+    }
+
+    @Override
+    public List<PropertyEntity> deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        List<PropertyEntity> properties = new ArrayList<>();
+
+        if (node.isArray()) {
+            node
+                .elements()
+                .forEachRemaining(
+                    jsonNode -> {
+                        try {
+                            PropertyEntity property = jsonNode.traverse(jp.getCodec()).readValueAs(PropertyEntity.class);
+                            properties.add(property);
+                        } catch (IOException e) {
+                            LOGGER.error("Error while deserializing API's properties list", e);
+                        }
+                    }
+                );
+        } else if (node.isObject()) {
+            node.fields().forEachRemaining(jsonNode -> properties.add(new PropertyEntity(jsonNode.getKey(), jsonNode.getValue().asText())));
+        }
+
+        return properties;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PropertiesEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/PropertiesEntityTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import static org.junit.Assert.*;
+
+import io.gravitee.definition.model.Properties;
+import java.util.List;
+import org.junit.Test;
+
+public class PropertiesEntityTest {
+
+    @Test
+    public void should_convert_to_definition_model_properties() {
+        PropertiesEntity propertiesEntity = new PropertiesEntity(
+            List.of(
+                new PropertyEntity("key1", "value1", true, false),
+                new PropertyEntity("key2", "value2", false, true),
+                new PropertyEntity("key3", "value3", true, true)
+            )
+        );
+
+        Properties properties = propertiesEntity.toDefinition();
+
+        assertEquals(propertiesEntity.getProperties(), properties.getProperties());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/jackson/PropertiesEntityAsListDeserializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/jackson/PropertiesEntityAsListDeserializerTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.jackson;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.gravitee.rest.api.model.PropertyEntity;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PropertiesEntityAsListDeserializerTest {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    @Before
+    public void setupDeserializer() {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(List.class, new PropertiesEntityAsListDeserializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    public void should_deserialize_empty_properties_list() throws JsonProcessingException {
+        List<PropertyEntity> properties = objectMapper.readValue("[]", List.class);
+        assertTrue(properties.isEmpty());
+    }
+
+    @Test
+    public void should_deserialize_properties_list() throws JsonProcessingException {
+        List<PropertyEntity> properties = objectMapper.readValue(
+            "[" +
+            "{\"key\":\"key1\", \"value\":\"value1\", \"encryptable\":\"true\", \"encrypted\":\"false\"}," +
+            "{\"key\":\"key2\", \"value\":\"value2\", \"encryptable\":\"false\", \"encrypted\":\"false\"}," +
+            "{\"key\":\"key3\", \"value\":\"value3\", \"encryptable\":\"true\", \"encrypted\":\"true\"}" +
+            "]",
+            List.class
+        );
+
+        List<PropertyEntity> expectedProperties = List.of(
+            new PropertyEntity("key1", "value1", true, false),
+            new PropertyEntity("key2", "value2", false, false),
+            new PropertyEntity("key3", "value3", true, true)
+        );
+
+        assertEquals(expectedProperties, properties);
+    }
+
+    @Test
+    public void should_deserialize_properties_object() throws JsonProcessingException {
+        List<PropertyEntity> properties = objectMapper.readValue(
+            "{" + "\"key1\": \"value1\"," + "\"key2\": \"value2\"," + "\"key3\": \"value3\"" + "}",
+            List.class
+        );
+
+        List<PropertyEntity> expectedProperties = List.of(
+            new PropertyEntity("key1", "value1"),
+            new PropertyEntity("key2", "value2"),
+            new PropertyEntity("key3", "value3")
+        );
+
+        assertEquals(expectedProperties, properties);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -108,7 +108,7 @@ public interface ApiService {
         updateApiEntity.setProxy(apiEntity.getProxy());
         updateApiEntity.setVersion(apiEntity.getVersion());
         updateApiEntity.setName(apiEntity.getName());
-        updateApiEntity.setProperties(apiEntity.getProperties());
+        updateApiEntity.setProperties(new PropertiesEntity(apiEntity.getProperties()));
         updateApiEntity.setDescription(apiEntity.getDescription());
         updateApiEntity.setGroups(apiEntity.getGroups());
         updateApiEntity.setPaths(apiEntity.getPaths());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -104,7 +104,6 @@ public interface ApiService {
 
     static UpdateApiEntity convert(ApiEntity apiEntity) {
         UpdateApiEntity updateApiEntity = new UpdateApiEntity();
-
         updateApiEntity.setProxy(apiEntity.getProxy());
         updateApiEntity.setVersion(apiEntity.getVersion());
         updateApiEntity.setName(apiEntity.getName());
@@ -126,7 +125,8 @@ public interface ApiService {
         updateApiEntity.setGraviteeDefinitionVersion(apiEntity.getGraviteeDefinitionVersion());
         updateApiEntity.setFlowMode(apiEntity.getFlowMode());
         updateApiEntity.setResponseTemplates(apiEntity.getResponseTemplates());
-
+        updateApiEntity.setCategories(apiEntity.getCategories());
+        updateApiEntity.setDisableMembershipNotifications(apiEntity.isDisableMembershipNotifications());
         return updateApiEntity;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -125,7 +125,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         final String apiId = apiEntity.getId();
         LOGGER.debug("Duplicate API {}", apiId);
 
-        final UpdateApiEntity newApiEntity = convert(apiEntity);
+        final UpdateApiEntity newApiEntity = ApiService.convert(apiEntity);
         final Proxy proxy = apiEntity.getProxy();
         proxy.setVirtualHosts(singletonList(new VirtualHost(duplicateApiEntity.getContextPath())));
         newApiEntity.setProxy(proxy);
@@ -298,33 +298,6 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         asideSystemFolder.setType(PageType.SYSTEM_FOLDER);
         asideSystemFolder.setVisibility(io.gravitee.rest.api.model.Visibility.PUBLIC);
         pageService.createPage(apiId, asideSystemFolder, environmentId);
-    }
-
-    private UpdateApiEntity convert(final ApiEntity apiEntity) {
-        final UpdateApiEntity updateApiEntity = new UpdateApiEntity();
-        updateApiEntity.setDescription(apiEntity.getDescription());
-        updateApiEntity.setName(apiEntity.getName());
-        updateApiEntity.setVersion(apiEntity.getVersion());
-        updateApiEntity.setGraviteeDefinitionVersion(apiEntity.getGraviteeDefinitionVersion());
-        updateApiEntity.setGroups(apiEntity.getGroups());
-        updateApiEntity.setLabels(apiEntity.getLabels());
-        updateApiEntity.setLifecycleState(apiEntity.getLifecycleState());
-        updateApiEntity.setPicture(apiEntity.getPicture());
-        updateApiEntity.setBackground(apiEntity.getBackground());
-        updateApiEntity.setProperties(new PropertiesEntity(apiEntity.getProperties()));
-        updateApiEntity.setProxy(apiEntity.getProxy());
-        updateApiEntity.setResources(apiEntity.getResources());
-        updateApiEntity.setResponseTemplates(apiEntity.getResponseTemplates());
-        updateApiEntity.setServices(apiEntity.getServices());
-        updateApiEntity.setTags(apiEntity.getTags());
-        updateApiEntity.setCategories(apiEntity.getCategories());
-        updateApiEntity.setVisibility(apiEntity.getVisibility());
-        updateApiEntity.setPaths(apiEntity.getPaths());
-        updateApiEntity.setFlows(apiEntity.getFlows());
-        updateApiEntity.setPathMappings(apiEntity.getPathMappings());
-        updateApiEntity.setDisableMembershipNotifications(apiEntity.isDisableMembershipNotifications());
-        updateApiEntity.setPlans(apiEntity.getPlans());
-        return updateApiEntity;
     }
 
     private String fetchApiDefinitionContentFromURL(String apiDefinitionOrURL) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -311,7 +311,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         updateApiEntity.setLifecycleState(apiEntity.getLifecycleState());
         updateApiEntity.setPicture(apiEntity.getPicture());
         updateApiEntity.setBackground(apiEntity.getBackground());
-        updateApiEntity.setProperties(apiEntity.getProperties());
+        updateApiEntity.setProperties(new PropertiesEntity(apiEntity.getProperties()));
         updateApiEntity.setProxy(apiEntity.getProxy());
         updateApiEntity.setResources(apiEntity.getResources());
         updateApiEntity.setResponseTemplates(apiEntity.getResponseTemplates());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1203,7 +1203,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Override
     public ApiEntity updateFromSwagger(String apiId, SwaggerApiEntity swaggerApiEntity, ImportSwaggerDescriptorEntity swaggerDescriptor) {
         final ApiEntity apiEntityToUpdate = this.findById(apiId);
-        final UpdateApiEntity updateApiEntity = convert(apiEntityToUpdate);
+        final UpdateApiEntity updateApiEntity = ApiService.convert(apiEntityToUpdate);
 
         // Overwrite from swagger
         updateApiEntity.setVersion(swaggerApiEntity.getVersion());
@@ -2428,33 +2428,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             LOGGER.error("An error occurs while trying to remove group {} from API {}: {}", group, apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to remove group " + group + " from API " + apiId, ex);
         }
-    }
-
-    private UpdateApiEntity convert(final ApiEntity apiEntity) {
-        final UpdateApiEntity updateApiEntity = new UpdateApiEntity();
-        updateApiEntity.setDescription(apiEntity.getDescription());
-        updateApiEntity.setName(apiEntity.getName());
-        updateApiEntity.setVersion(apiEntity.getVersion());
-        updateApiEntity.setGraviteeDefinitionVersion(apiEntity.getGraviteeDefinitionVersion());
-        updateApiEntity.setGroups(apiEntity.getGroups());
-        updateApiEntity.setLabels(apiEntity.getLabels());
-        updateApiEntity.setLifecycleState(apiEntity.getLifecycleState());
-        updateApiEntity.setPicture(apiEntity.getPicture());
-        updateApiEntity.setBackground(apiEntity.getBackground());
-        updateApiEntity.setProperties(new PropertiesEntity(apiEntity.getProperties()));
-        updateApiEntity.setProxy(apiEntity.getProxy());
-        updateApiEntity.setResources(apiEntity.getResources());
-        updateApiEntity.setResponseTemplates(apiEntity.getResponseTemplates());
-        updateApiEntity.setServices(apiEntity.getServices());
-        updateApiEntity.setTags(apiEntity.getTags());
-        updateApiEntity.setCategories(apiEntity.getCategories());
-        updateApiEntity.setVisibility(apiEntity.getVisibility());
-        updateApiEntity.setPaths(apiEntity.getPaths());
-        updateApiEntity.setFlows(apiEntity.getFlows());
-        updateApiEntity.setPathMappings(apiEntity.getPathMappings());
-        updateApiEntity.setDisableMembershipNotifications(apiEntity.isDisableMembershipNotifications());
-        updateApiEntity.setPlans(apiEntity.getPlans());
-        return updateApiEntity;
     }
 
     private ApiEntity updateWorkflowReview(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -244,12 +244,12 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
 
             // Properties
             if (xGraviteeIODefinition.getProperties() != null && !xGraviteeIODefinition.getProperties().isEmpty()) {
-                Properties properties = new Properties();
+                PropertiesEntity properties = new PropertiesEntity();
                 properties.setProperties(
                     xGraviteeIODefinition
                         .getProperties()
                         .stream()
-                        .map(prop -> new Property(prop.getKey(), prop.getValue()))
+                        .map(prop -> new PropertyEntity(prop.getKey(), prop.getValue()))
                         .collect(Collectors.toList())
                 );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
@@ -29,6 +29,7 @@ import com.github.fge.jsonschema.library.LibraryBuilder;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.event.impl.EventManagerImpl;
+import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.plugin.alert.spring.AlertPluginConfiguration;
 import io.gravitee.plugin.discovery.spring.ServiceDiscoveryPluginConfiguration;
@@ -49,10 +50,12 @@ import io.gravitee.rest.api.service.quality.ApiQualityMetricLoader;
 import io.gravitee.rest.api.service.validator.RegexPasswordValidator;
 import io.gravitee.rest.api.service.validator.jsonschema.JavaRegexFormatAttribute;
 import java.util.Collections;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
@@ -76,6 +79,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
     }
 )
 public class ServiceConfiguration {
+
+    @Autowired
+    private Environment environment;
 
     @Bean
     public EventManager eventManager() {
@@ -138,5 +144,10 @@ public class ServiceConfiguration {
             .setReportProvider(new ListReportProvider(LogLevel.ERROR, LogLevel.FATAL)) // Log errors only, throw fatal exceptions only
             .setValidationConfiguration(cfg.freeze())
             .freeze();
+    }
+
+    @Bean
+    public DataEncryptor apiPropertiesEncryptor() {
+        return new DataEncryptor(environment, "api.properties.encryption.secret", "vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
@@ -210,7 +210,7 @@ public class SwaggerService_CreateAPITest {
         assertEquals(2, tags.size());
         assertTrue(tags.containsAll(asList("tagId1", "tagId2")));
 
-        final Map<String, String> properties = updateApiEntity.getProperties().getValues();
+        final Map<String, String> properties = updateApiEntity.getProperties().toDefinition().getValues();
         assertEquals(2, properties.size());
         assertTrue(properties.keySet().containsAll(asList("prop1", "prop2")));
         assertTrue(properties.values().containsAll(asList("propValue1", "propValue2")));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiServiceImplTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.Property;
+import io.gravitee.rest.api.model.PropertyEntity;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiServiceImplTest {
+
+    @InjectMocks
+    private ApiServiceImpl apiService;
+
+    @Mock
+    private DataEncryptor dataEncryptor;
+
+    @Test
+    public void encryptProperties_should_call_data_encryptor_for_each_encryptable_property_not_yet_encrypted()
+        throws GeneralSecurityException {
+        List<PropertyEntity> properties = buildProperties();
+
+        apiService.encryptProperties(properties);
+
+        verify(dataEncryptor, times(1)).encrypt("value2");
+        verify(dataEncryptor, times(1)).encrypt("value4");
+        verifyNoMoreInteractions(dataEncryptor);
+    }
+
+    @Test
+    public void encryptProperties_should_set_encrypted_boolean_true_for_each_encrypted_property() throws GeneralSecurityException {
+        List<PropertyEntity> properties = buildProperties();
+
+        apiService.encryptProperties(properties);
+
+        assertFalse(properties.get(0).isEncrypted());
+        assertTrue(properties.get(1).isEncrypted());
+        assertTrue(properties.get(2).isEncrypted());
+        assertTrue(properties.get(3).isEncrypted());
+    }
+
+    @Test
+    public void encryptProperties_should_set_value_of_each_encrypted_property() throws GeneralSecurityException {
+        List<PropertyEntity> properties = buildProperties();
+        when(dataEncryptor.encrypt("value2")).thenReturn("encryptedValue2");
+        when(dataEncryptor.encrypt("value4")).thenReturn("encryptedValue4");
+
+        apiService.encryptProperties(properties);
+
+        assertEquals("value1", properties.get(0).getValue());
+        assertEquals("encryptedValue2", properties.get(1).getValue());
+        assertEquals("value3", properties.get(2).getValue());
+        assertEquals("encryptedValue4", properties.get(3).getValue());
+    }
+
+    private List<PropertyEntity> buildProperties() {
+        return List.of(
+            new PropertyEntity("key1", "value1", false, false),
+            new PropertyEntity("key2", "value2", true, false),
+            new PropertyEntity("key3", "value3", true, true),
+            new PropertyEntity("key4", "value4", true, false)
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/themes/definition.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/themes/definition.json
@@ -543,6 +543,34 @@
           "type": "string",
           "default": "auto",
           "value": "auto"
+        },
+        {
+          "name": "--gv-table--colmg",
+          "description": "Column gap",
+          "type": "length",
+          "default": "0.2rem",
+          "value": "0.2rem"
+        },
+        {
+          "name": "--gv-table-row--ai",
+          "description": "Row align-items",
+          "type": "string",
+          "default": "center",
+          "value": "center"
+        },
+        {
+          "name": "--gv-table-row--ac",
+          "description": "Row align-content",
+          "type": "string",
+          "default": "center",
+          "value": "center"
+        },
+        {
+          "name": "--gv-table-cell--d",
+          "description": "Cell display",
+          "type": "string",
+          "default": "flex",
+          "value": "flex"
         }
       ]
     },
@@ -1207,6 +1235,13 @@
           "type": "color",
           "default": "var(--gv-theme-neutral-color-lightest, #ffffff)",
           "value": ""
+        },
+        {
+          "name": "--gv-switch--ta",
+          "description": "Switch label text alignment",
+          "type": "string",
+          "default": "left",
+          "value": "left"
         }
       ]
     },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -544,3 +544,9 @@ notifiers:
 # Specify the URL to cockpit instance. Default is the Gravitee SAAS instance
 #cockpit:
 #  url: https://cockpit.gravitee.io
+
+# Encrypt API properties using this secret
+api:
+  properties:
+    encryption:
+      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/5638

encrypt API properties on API creation and update

Encryption is done using the DataEncryptor, which bean is configured in ApiPropertiesEncryptorConfiguration.
Working like other encryptions processes in gravitee : a default secret key has to be overriden in yml configuration, or a security warning message is displayed at startup.