### PR TITLE
Use project version in Maven sub modules

### DIFF
--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -43,7 +43,6 @@
         <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
-        <gravitee-api-management.version>3.9.4-SNAPSHOT</gravitee-api-management.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.0.0</gravitee-resource-cache-provider-api.version>
         <gravitee-cockpit-api.version>1.5.0</gravitee-cockpit-api.version>
@@ -112,7 +111,7 @@
             <dependency>
                 <groupId>io.gravitee.apim.repository</groupId>
                 <artifactId>gravitee-apim-repository-api</artifactId>
-                <version>${gravitee-api-management.version}</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.common</groupId>


### PR DESCRIPTION
**Issue**

NA

**Description**

After merging the Rest API on the monorepo we missed removing a version, so now we use project version in Maven sub modules directly.


