### PR TITLE
feat: allow access to SSL attributes in EL TemplateEngine

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/spel/grammar.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/spel/grammar.json
@@ -1,1 +1,425 @@
-{"request":{"headers":{"_type":"HttpHeaders"},"method":{"_type":"String"},"scheme":{"_type":"String"},"pathParams":{"_type":"MultiValueMap"},"pathInfos":{"_type":"String[]"},"contextPath":{"_type":"String"},"params":{"_type":"MultiValueMap"},"uri":{"_type":"String"},"version":{"_type":"String"},"content":{"_type":"String"},"transactionId":{"_type":"String"},"path":{"_type":"String"},"localAddress":{"_type":"String"},"paths":{"_type":"String[]"},"id":{"_type":"String"},"pathInfo":{"_type":"String"},"remoteAddress":{"_type":"String"},"timestamp":{"_type":"long"}},"endpoints":{"_type":"String[]"},"response":{"headers":{"_type":"HttpHeaders"},"content":{"_type":"String"},"status":{"_type":"int"}},"context":{"attributes":{"context-path":{"_type":"String"},"application":{"_type":"String"},"api-key":{"_type":"String"},"user-id":{"_type":"String"},"api":{"_type":"String"},"plan":{"_type":"String"},"resolved-path":{"_type":"String"}}},"_enums":{"HttpHeaders":["Accept","Accept-Charset","Accept-Encoding","Accept-Language","Accept-Ranges","Access-Control-Allow-Credentials","Access-Control-Allow-Headers","Access-Control-Allow-Methods","Access-Control-Allow-Origin","Access-Control-Expose-Headers","Access-Control-Max-Age","Access-Control-Request-Headers","Access-Control-Request-Method","Age","Allow","Authorization","Cache-Control","Connection","Content-Disposition","Content-Encoding","Content-ID","Content-Language","Content-Length","Content-Location","Content-MD5","Content-Range","Content-Type","Cookie","Date","ETag","Expires","Expect","Forwarded","From","Host","If-Match","If-Modified-Since","If-None-Match","If-Unmodified-Since","Keep-Alive","Last-Modified","Location","Link","Max-Forwards","MIME-Version","Origin","Pragma","Proxy-Authenticate","Proxy-Authorization","Proxy-Connection","Range","Referer","Retry-After","Server","Set-Cookie","Set-Cookie2","TE","Trailer","Transfer-Encoding","Upgrade","User-Agent","Vary","Via","Warning","WWW-Authenticate","X-Forwarded-For","X-Forwarded-Proto","X-Forwarded-Server","X-Forwarded-Host"]},"properties":{"_type":"String[]"},"dictionaries":{"_type":"String[]"}}
+{
+  "request": {
+    "content": {
+      "_type": "String"
+    },
+    "contextPath": {
+      "_type": "String"
+    },
+    "headers": {
+      "_type": "HttpHeaders"
+    },
+    "id": {
+      "_type": "String"
+    },
+    "localAddress": {
+      "_type": "String"
+    },
+    "params": {
+      "_type": "MultiValueMap"
+    },
+    "path": {
+      "_type": "String"
+    },
+    "pathInfo": {
+      "_type": "String"
+    },
+    "pathInfos": {
+      "_type": "String[]"
+    },
+    "pathParams": {
+      "_type": "MultiValueMap"
+    },
+    "paths": {
+      "_type": "String[]"
+    },
+    "remoteAddress": {
+      "_type": "String"
+    },
+    "scheme": {
+      "_type": "String"
+    },
+    "ssl": {
+      "client": {
+        "businessCategory": {
+          "_type": "String"
+        },
+        "c": {
+          "_type": "String"
+        },
+        "cn": {
+          "_type": "String"
+        },
+        "countryOfCitizenship": {
+          "_type": "String"
+        },
+        "countryOfResidence": {
+          "_type": "String"
+        },
+        "dateOfBirth": {
+          "_type": "String"
+        },
+        "dc": {
+          "_type": "String"
+        },
+        "description": {
+          "_type": "String"
+        },
+        "dmdName": {
+          "_type": "String"
+        },
+        "dn": {
+          "_type": "String"
+        },
+        "dnQualifier": {
+          "_type": "String"
+        },
+        "e": {
+          "_type": "String"
+        },
+        "emailAddress": {
+          "_type": "String"
+        },
+        "gender": {
+          "_type": "String"
+        },
+        "generation": {
+          "_type": "String"
+        },
+        "get(String attributeName)": {
+          "_type": "String"
+        },
+        "getAll(String attributeName)": {
+          "_type": "String[]"
+        },
+        "givenname": {
+          "_type": "String"
+        },
+        "initials": {
+          "_type": "String"
+        },
+        "isDefined()": {
+          "_type": "boolean"
+        },
+        "l": {
+          "_type": "String"
+        },
+        "name": {
+          "_type": "String"
+        },
+        "nameAtBirth": {
+          "_type": "String"
+        },
+        "o": {
+          "_type": "String"
+        },
+        "organizationIdentifier": {
+          "_type": "String"
+        },
+        "ou": {
+          "_type": "String"
+        },
+        "placeOfBirth": {
+          "_type": "String"
+        },
+        "postalAddress": {
+          "_type": "String"
+        },
+        "postalCode": {
+          "_type": "String"
+        },
+        "pseudonym": {
+          "_type": "String"
+        },
+        "role": {
+          "_type": "String"
+        },
+        "serialnumber": {
+          "_type": "String"
+        },
+        "st": {
+          "_type": "String"
+        },
+        "street": {
+          "_type": "String"
+        },
+        "surname": {
+          "_type": "String"
+        },
+        "t": {
+          "_type": "String"
+        },
+        "telephoneNumber": {
+          "_type": "String"
+        },
+        "uid": {
+          "_type": "String"
+        },
+        "uniqueIdentifier": {
+          "_type": "String"
+        },
+        "unstructuredAddress": {
+          "_type": "String"
+        }
+      },
+      "clientHost": {
+        "_type": "String"
+      },
+      "clientPort": {
+        "_type": "Integer"
+      },
+      "server": {
+        "businessCategory": {
+          "_type": "String"
+        },
+        "c": {
+          "_type": "String"
+        },
+        "cn": {
+          "_type": "String"
+        },
+        "countryOfCitizenship": {
+          "_type": "String"
+        },
+        "countryOfResidence": {
+          "_type": "String"
+        },
+        "dateOfBirth": {
+          "_type": "String"
+        },
+        "dc": {
+          "_type": "String"
+        },
+        "description": {
+          "_type": "String"
+        },
+        "dmdName": {
+          "_type": "String"
+        },
+        "dn": {
+          "_type": "String"
+        },
+        "dnQualifier": {
+          "_type": "String"
+        },
+        "e": {
+          "_type": "String"
+        },
+        "emailAddress": {
+          "_type": "String"
+        },
+        "gender": {
+          "_type": "String"
+        },
+        "generation": {
+          "_type": "String"
+        },
+        "get(String attributeName)": {
+          "_type": "String"
+        },
+        "getAll(String attributeName)": {
+          "_type": "String[]"
+        },
+        "givenname": {
+          "_type": "String"
+        },
+        "initials": {
+          "_type": "String"
+        },
+        "isDefined()": {
+          "_type": "boolean"
+        },
+        "l": {
+          "_type": "String"
+        },
+        "name": {
+          "_type": "String"
+        },
+        "nameAtBirth": {
+          "_type": "String"
+        },
+        "o": {
+          "_type": "String"
+        },
+        "organizationIdentifier": {
+          "_type": "String"
+        },
+        "ou": {
+          "_type": "String"
+        },
+        "placeOfBirth": {
+          "_type": "String"
+        },
+        "postalAddress": {
+          "_type": "String"
+        },
+        "postalCode": {
+          "_type": "String"
+        },
+        "pseudonym": {
+          "_type": "String"
+        },
+        "role": {
+          "_type": "String"
+        },
+        "serialnumber": {
+          "_type": "String"
+        },
+        "st": {
+          "_type": "String"
+        },
+        "street": {
+          "_type": "String"
+        },
+        "surname": {
+          "_type": "String"
+        },
+        "t": {
+          "_type": "String"
+        },
+        "telephoneNumber": {
+          "_type": "String"
+        },
+        "uid": {
+          "_type": "String"
+        },
+        "uniqueIdentifier": {
+          "_type": "String"
+        },
+        "unstructuredAddress": {
+          "_type": "String"
+        }
+      }
+    },
+    "timestamp": {
+      "_type": "long"
+    },
+    "transactionId": {
+      "_type": "String"
+    },
+    "uri": {
+      "_type": "String"
+    },
+    "version": {
+      "_type": "String"
+    }
+  },
+  "endpoints": {
+    "_type": "String[]"
+  },
+  "response": {
+    "headers": {
+      "_type": "HttpHeaders"
+    },
+    "content": {
+      "_type": "String"
+    },
+    "status": {
+      "_type": "int"
+    }
+  },
+  "context": {
+    "attributes": {
+      "context-path": {
+        "_type": "String"
+      },
+      "application": {
+        "_type": "String"
+      },
+      "api-key": {
+        "_type": "String"
+      },
+      "user-id": {
+        "_type": "String"
+      },
+      "api": {
+        "_type": "String"
+      },
+      "plan": {
+        "_type": "String"
+      },
+      "resolved-path": {
+        "_type": "String"
+      }
+    }
+  },
+  "_enums": {
+    "HttpHeaders": [
+      "Accept",
+      "Accept-Charset",
+      "Accept-Encoding",
+      "Accept-Language",
+      "Accept-Ranges",
+      "Access-Control-Allow-Credentials",
+      "Access-Control-Allow-Headers",
+      "Access-Control-Allow-Methods",
+      "Access-Control-Allow-Origin",
+      "Access-Control-Expose-Headers",
+      "Access-Control-Max-Age",
+      "Access-Control-Request-Headers",
+      "Access-Control-Request-Method",
+      "Age",
+      "Allow",
+      "Authorization",
+      "Cache-Control",
+      "Connection",
+      "Content-Disposition",
+      "Content-Encoding",
+      "Content-ID",
+      "Content-Language",
+      "Content-Length",
+      "Content-Location",
+      "Content-MD5",
+      "Content-Range",
+      "Content-Type",
+      "Cookie",
+      "Date",
+      "ETag",
+      "Expires",
+      "Expect",
+      "Forwarded",
+      "From",
+      "Host",
+      "If-Match",
+      "If-Modified-Since",
+      "If-None-Match",
+      "If-Unmodified-Since",
+      "Keep-Alive",
+      "Last-Modified",
+      "Location",
+      "Link",
+      "Max-Forwards",
+      "MIME-Version",
+      "Origin",
+      "Pragma",
+      "Proxy-Authenticate",
+      "Proxy-Authorization",
+      "Proxy-Connection",
+      "Range",
+      "Referer",
+      "Retry-After",
+      "Server",
+      "Set-Cookie",
+      "Set-Cookie2",
+      "TE",
+      "Trailer",
+      "Transfer-Encoding",
+      "Upgrade",
+      "User-Agent",
+      "Vary",
+      "Via",
+      "Warning",
+      "WWW-Authenticate",
+      "X-Forwarded-For",
+      "X-Forwarded-Proto",
+      "X-Forwarded-Server",
+      "X-Forwarded-Host"
+    ]
+  },
+  "properties": {
+    "_type": "String[]"
+  },
+  "dictionaries": {
+    "_type": "String[]"
+  }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5322

**Description**

Update the EL grammar.json, so the EL Autocomplete WebComponent can display the new entries.

**Additional context**

I used a TreeMap to sort alphabetically the fields