### PR TITLE
fix: return the total number of elements in paged result

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
@@ -54,13 +54,14 @@ public class AlertEventMongoRepositoryImpl implements AlertEventMongoRepositoryC
         // set sort by updated at
         query.with(Sort.by(Sort.Direction.DESC, "createdAt"));
 
+        long total = mongoTemplate.count(query, AlertEventMongo.class);
+
         // set pageable
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
         }
 
         List<AlertEventMongo> events = mongoTemplate.find(query, AlertEventMongo.class);
-        long total = mongoTemplate.count(query, AlertEventMongo.class);
 
         return new Page<>(events, (pageable != null) ? pageable.pageNumber() : 0, events.size(), total);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ticket/TicketMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ticket/TicketMongoRepositoryImpl.java
@@ -72,6 +72,8 @@ public class TicketMongoRepositoryImpl implements TicketMongoRepositoryCustom {
             }
         }
 
+        long total = mongoTemplate.count(query, TicketMongo.class);
+
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
         }
@@ -80,7 +82,6 @@ public class TicketMongoRepositoryImpl implements TicketMongoRepositoryCustom {
         query.collation(Collation.of(Locale.ENGLISH).strength(Collation.ComparisonLevel.secondary()));
 
         List<TicketMongo> tickets = mongoTemplate.find(query, TicketMongo.class);
-        long total = mongoTemplate.count(query, TicketMongo.class);
 
         return new Page<>(tickets, (pageable != null) ? pageable.pageNumber() : 0, tickets.size(), total);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepositoryImpl.java
@@ -57,12 +57,14 @@ public class UserMongoRepositoryImpl implements UserMongoRepositoryCustom {
             }
         }
         query.with(Sort.by(Sort.Direction.ASC, "lastname", "firstname"));
+
+        long total = mongoTemplate.count(query, UserMongo.class);
+
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
         }
 
         List<UserMongo> users = mongoTemplate.find(query, UserMongo.class);
-        long total = mongoTemplate.count(query, UserMongo.class);
 
         return new Page<>(users, (pageable != null) ? pageable.pageNumber() : 0, users.size(), total);
     }


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/6173

**Description**
When searching for Users, Alert events and tickets in mongo repository, the total number of elements is computed on the paged result and not on the full collection.

Changes : Calculate the total before adding the size filter to the mongo query

**Additional context**

After discussion with Flo it does not seem necessary to add unit tests 

