### PR TITLE
fix: add missing `apim` in zip name

### DIFF
--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get --yes install wget unzip htop \
 	&& wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-full-${GRAVITEEIO_VERSION}.zip --no-check-certificate -P /tmp \
     && unzip /tmp/graviteeio-full-${GRAVITEEIO_VERSION}.zip -d /tmp/ \
-    && mv /tmp/graviteeio-full-${GRAVITEEIO_VERSION}/graviteeio-rest-api* ${GRAVITEEIO_HOME} \
+    && mv /tmp/graviteeio-full-${GRAVITEEIO_VERSION}/graviteeio-apim-rest-api* ${GRAVITEEIO_HOME} \
     && rm -rf /tmp/* \
     && rm -rf /var/lib/apt/lists/* \
 	&& chgrp -R 0 ${GRAVITEEIO_HOME} \


### PR DESCRIPTION
**Issue**

gravitee-io/issues#6206

**Description**

During the 3.10.2 (#6139) and the upgrade of docker base image, the path to apim zip has been revert to an old name.
So the docker generation doesn't work.



