### PR TITLE
fix: instantiate the right inputStream instead of relying on the registry

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.InlinePictureEntity;
 import io.gravitee.rest.api.model.MediaEntity;
@@ -153,7 +154,13 @@ public abstract class AbstractResource {
             }
 
             try {
-                ImageInputStream imageInputStream = ImageIO.createImageInputStream(decodedPicture);
+                /*
+                 * For an unknown reason, when running APIM from jar/zip instead of sourcecode, com.twelvemonkeys.imageio.stream.ByteArrayImageInputStreamSpi
+                 *  is not registered in the IIORegistry used by ImageIO to manage stream.
+                 * So basically the hack is to directly instantiate a ByteArrayImageInputStream
+                 */
+                //ImageInputStream imageInputStream = ImageIO.createImageInputStream(decodedPicture);
+                ImageInputStream imageInputStream = new ByteArrayImageInputStream(decodedPicture);
                 Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(imageInputStream);
 
                 while (imageReaders.hasNext()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/utils/ImageUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/utils/ImageUtils.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.security.utils;
 
+import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import io.gravitee.rest.api.exception.InvalidImageException;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -114,7 +115,13 @@ public final class ImageUtils {
 
     private static Image rescale(Image image, int width, int height) throws InvalidImageException {
         try {
-            ImageInputStream imageInputStream = ImageIO.createImageInputStream(image.getData());
+            /*
+             * For an unknown reason, when running APIM from jar/zip instead of sourcecode, com.twelvemonkeys.imageio.stream.ByteArrayImageInputStreamSpi
+             *  is not registered in the IIORegistry used by ImageIO to manage stream.
+             * So basically the hack is to directly instantiate a ByteArrayImageInputStream
+             */
+            //ImageInputStream imageInputStream = ImageIO.createImageInputStream(image.getData());
+            ImageInputStream imageInputStream = new ByteArrayImageInputStream(image.getData());
             Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(imageInputStream);
 
             while (imageReaders.hasNext()) {


### PR DESCRIPTION
For an unknown reason, when running APIM from jar/zip instead of sourcecode, `com.twelvemonkeys.imageio.stream.ByteArrayImageInputStreamSpi` is not registered in the `IIORegistry` used by `ImageIO` to manage stream.
So basically the hack is to directly instantiate a `ByteArrayImageInputStream`