### PR TITLE
fix: filter again the result of the search

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2798,7 +2798,17 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         Query<ApiEntity> apiQuery = QueryBuilder.create(ApiEntity.class).setQuery(query).setFilters(filters).build();
 
         SearchResult matchApis = searchEngineService.search(apiQuery);
-        return matchApis.getDocuments().stream().map(this::findById).collect(toList());
+
+        /*
+         * Dirty hack to ensure that only APIs viewable by the current user are returned
+         */
+        Stream<String> apiIdStream = matchApis.getDocuments().stream();
+        if (filters.containsKey("api")) {
+            Set<String> availableApis = (Set) filters.get("api");
+            apiIdStream = apiIdStream.filter(availableApis::contains);
+        }
+
+        return apiIdStream.map(this::findById).collect(toList());
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6285

**Description**

since modifying the Lucene request is too complex, I prefer add a quick fix to prevent not wanted APIs to be returned.

