### PR TITLE
fix: bump gravitee-cockpit version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>1.8.0-SNAPSHOT</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>1.8.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.22.0</gravitee-common.version>
         <gravitee-definition.version>1.29.1</gravitee-definition.version>
         <gravitee-expression-language.version>1.6.1</gravitee-expression-language.version>


### PR DESCRIPTION
**Description**

Bump version of gravitee-cockpit, since 1.8.0 has been released