### PR TITLE
fix: fix application search by name when user is admin

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
@@ -74,7 +74,7 @@ public class ApplicationsResource extends AbstractResource {
         Set<ApplicationListItem> applications;
 
         if (query != null && !query.trim().isEmpty()) {
-            applications = applicationService.findByName(isAdmin() ? null : getAuthenticatedUser(), query);
+            applications = applicationService.findByUserAndName(getAuthenticatedUser(), isAdmin(), query);
         } else if (isAdmin()) {
             applications = group != null ? applicationService.findByGroups(Collections.singletonList(group)) : applicationService.findAll();
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
@@ -33,7 +33,9 @@ public interface ApplicationService {
 
     Set<ApplicationListItem> findByUser(String username);
 
-    Set<ApplicationListItem> findByName(String username, String name);
+    Set<ApplicationListItem> findByUserAndName(String username, String name);
+
+    Set<ApplicationListItem> findByUserAndName(String username, boolean isAdminUser, String name);
 
     Set<ApplicationListItem> findByGroups(List<String> groupId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByUserAndNameTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByUserAndNameTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.*;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
+import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
@@ -43,7 +44,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author GraviteeSource Team
  */
 @RunWith(MockitoJUnitRunner.class)
-public class ApplicationService_FindByNameTest {
+public class ApplicationService_FindByUserAndNameTest {
 
     @InjectMocks
     private ApplicationServiceImpl applicationService = new ApplicationServiceImpl();
@@ -56,7 +57,7 @@ public class ApplicationService_FindByNameTest {
 
     @Test
     public void shouldNotFindByNameWhenNull() throws Exception {
-        Set<ApplicationListItem> set = applicationService.findByName(null, null);
+        Set<ApplicationListItem> set = applicationService.findByUserAndName("myUser", null);
         assertNotNull(set);
         assertEquals("result is empty", 0, set.size());
         verify(applicationRepository, never()).findByName(any());
@@ -64,17 +65,16 @@ public class ApplicationService_FindByNameTest {
 
     @Test
     public void shouldNotFindByNameWhenEmpty() throws Exception {
-        Set<ApplicationListItem> set = applicationService.findByName(null, " ");
+        Set<ApplicationListItem> set = applicationService.findByUserAndName("myUser", " ");
         assertNotNull(set);
         assertEquals("result is empty", 0, set.size());
         verify(applicationRepository, never()).findByName(any());
     }
 
     @Test
-    public void shouldNotFindByName() throws Exception {
-        when(membershipService.getMembershipsByMemberAndReference(any(), any(), any())).thenReturn(Collections.emptySet());
+    public void shouldFindByName() {
         when(applicationRepository.search(any(), any())).thenReturn(new Page<>(Collections.emptyList(), 0, 0, 0));
-        Set<ApplicationListItem> set = applicationService.findByName(null, "a");
+        Set<ApplicationListItem> set = applicationService.findByUserAndName("myUser", true, "a");
         assertNotNull(set);
         assertEquals("result is empty", 0, set.size());
         ArgumentCaptor<ApplicationCriteria> queryCaptor = ArgumentCaptor.forClass(ApplicationCriteria.class);
@@ -90,10 +90,54 @@ public class ApplicationService_FindByNameTest {
             .thenReturn(new HashSet<>());
 
         // call
-        Set<ApplicationListItem> resultSet = applicationService.findByName("myUser", "random search");
+        Set<ApplicationListItem> resultSet = applicationService.findByUserAndName("myUser", "random search");
 
         // check applicationRepository search has not been called, and so it returns empty
         assertTrue(resultSet.isEmpty());
         verify(applicationRepository, never()).search(any(), any());
+    }
+
+    @Test
+    public void shouldNotRetrieveMembershipsWhenUserIdAdminAndFindWithoutApplicationId() {
+        when(applicationRepository.search(any(), any())).thenReturn(new Page<>(Collections.emptyList(), 0, 0, 0));
+
+        // call
+        applicationService.findByUserAndName("myUser", true, "random search");
+
+        // check membership hasn't been retrieved
+        verify(membershipService, never()).getMembershipsByMemberAndReference(any(), any(), any());
+
+        // check applicationRepository search has been called without application
+        ArgumentCaptor<ApplicationCriteria> queryCaptor = ArgumentCaptor.forClass(ApplicationCriteria.class);
+        Mockito.verify(applicationRepository).search(queryCaptor.capture(), any());
+        assertTrue(queryCaptor.getValue().getIds().isEmpty());
+    }
+
+    @Test
+    public void shouldRetrieveMembershipsAndFindWithApplicationsId() {
+        when(applicationRepository.search(any(), any())).thenReturn(new Page<>(Collections.emptyList(), 0, 0, 0));
+
+        // mock applications memberships for this user : found applications "myApplicationId1" and "myApplicationId2"
+        MembershipEntity membership1 = new MembershipEntity();
+        membership1.setId("m1");
+        membership1.setReferenceId("myApplicationId1");
+        MembershipEntity membership2 = new MembershipEntity();
+        membership2.setId("m2");
+        membership2.setReferenceId("myApplicationId2");
+        Set<MembershipEntity> memberships = new HashSet<>();
+        memberships.add(membership1);
+        memberships.add(membership2);
+        when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, "myUser", MembershipReferenceType.APPLICATION))
+            .thenReturn(memberships);
+
+        // call
+        applicationService.findByUserAndName("myUser", "random search");
+
+        // check applicationRepository search has been called with applications
+        ArgumentCaptor<ApplicationCriteria> queryCaptor = ArgumentCaptor.forClass(ApplicationCriteria.class);
+        Mockito.verify(applicationRepository).search(queryCaptor.capture(), any());
+        assertEquals(2, queryCaptor.getValue().getIds().size());
+        assertEquals("myApplicationId1", queryCaptor.getValue().getIds().get(0));
+        assertEquals("myApplicationId2", queryCaptor.getValue().getIds().get(1));
     }
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/5812

When user is admin, we don't have to retrieve user's memberships to filter applications.
So, if ApplicationsService.findByUserAndName is called with a null userName, don't retrieve memberships, and search applications without id filter.