### PR TITLE
chore: don't attach full distrib to avoid deployment on nexus

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/pom.xml
@@ -80,6 +80,7 @@
 							<goal>single</goal>
 						</goals>
 						<configuration>
+							<attach>false</attach>
 							<finalName>gravitee-apim-rest-api-distribution-${project.version}</finalName>
 							<appendAssemblyId>false</appendAssemblyId>
 							<descriptors>


### PR DESCRIPTION
**Description**

Since we build a distribution zip with all plugins of Management API, this ZIP replaces the previous "standalone" one in nexus and has impacts on nightly builds
