### PR TITLE
Feat/mongo to JDBC in 3.5

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AlertTriggerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AlertTriggerRepository.java
@@ -25,7 +25,5 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface AlertTriggerRepository extends CrudRepository<AlertTrigger, String> {
-    Set<AlertTrigger> findAll() throws TechnicalException;
-
     List<AlertTrigger> findByReference(String referenceType, String referenceId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiHeaderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiHeaderRepository.java
@@ -24,7 +24,5 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ApiHeaderRepository extends CrudRepository<ApiHeader, String> {
-    Set<ApiHeader> findAll() throws TechnicalException;
-
     Set<ApiHeader> findAllByEnvironment(String environmentId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ApiKeyRepository {
+public interface ApiKeyRepository extends FindAllRepository<ApiKey> {
     /**
      * Give the API Key detail from the given key
      *

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiQualityRuleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiQualityRuleRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ApiQualityRuleRepository {
+public interface ApiQualityRuleRepository extends FindAllRepository<ApiQualityRule> {
     Optional<ApiQualityRule> findById(String api, String qualityRule) throws TechnicalException;
     ApiQualityRule create(ApiQualityRule apiQualityRule) throws TechnicalException;
     ApiQualityRule update(ApiQualityRule apiQualityRule) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CategoryRepository.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface CategoryRepository {
+public interface CategoryRepository extends FindAllRepository<Category> {
     Optional<Category> findById(String id) throws TechnicalException;
 
     Category create(Category item) throws TechnicalException;
@@ -34,8 +34,6 @@ public interface CategoryRepository {
     Category update(Category item) throws TechnicalException;
 
     void delete(String id) throws TechnicalException;
-
-    Set<Category> findAll() throws TechnicalException;
 
     Optional<Category> findByKey(String key, String environment) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CrudRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CrudRepository.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-interface CrudRepository<T, ID> {
+public interface CrudRepository<T, ID> extends FindAllRepository<T> {
     Optional<T> findById(ID id) throws TechnicalException;
 
     T create(T item) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CustomUserFieldsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CustomUserFieldsRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface CustomUserFieldsRepository {
+public interface CustomUserFieldsRepository extends FindAllRepository<CustomUserField> {
     CustomUserField create(CustomUserField field) throws TechnicalException;
 
     CustomUserField update(CustomUserField field) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DashboardRepository.java
@@ -18,13 +18,11 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Dashboard;
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface DashboardRepository extends CrudRepository<Dashboard, String> {
-    Set<Dashboard> findAll() throws TechnicalException;
     List<Dashboard> findByReferenceType(String referenceType) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DictionaryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DictionaryRepository.java
@@ -25,13 +25,6 @@ import java.util.Set;
  */
 public interface DictionaryRepository extends CrudRepository<Dictionary, String> {
     /**
-     * List all dictionaries
-     * @return all dictionaries
-     * @throws TechnicalException if something goes wrong
-     */
-    Set<Dictionary> findAll() throws TechnicalException;
-
-    /**
      * List all dictionaries by environment
      * @param environmentId
      * @return all dictionaries for a given environment

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/EnvironmentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/EnvironmentRepository.java
@@ -24,7 +24,5 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface EnvironmentRepository extends CrudRepository<Environment, String> {
-    Set<Environment> findAll() throws TechnicalException;
-
     Set<Environment> findByOrganization(String organizationId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FindAllRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FindAllRepository.java
@@ -16,15 +16,12 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.Group;
 import java.util.Set;
 
 /**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface GroupRepository extends CrudRepository<Group, String> {
-    Set<Group> findAllByEnvironment(String environmentId) throws TechnicalException;
-
-    Set<Group> findByIds(Set<String> ids) throws TechnicalException;
+public interface FindAllRepository<T> {
+    Set<T> findAll() throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GenericNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GenericNotificationConfigRepository.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface GenericNotificationConfigRepository {
+public interface GenericNotificationConfigRepository extends FindAllRepository<GenericNotificationConfig> {
     GenericNotificationConfig create(GenericNotificationConfig genericNotificationConfig) throws TechnicalException;
     GenericNotificationConfig update(GenericNotificationConfig genericNotificationConfig) throws TechnicalException;
     void delete(String id) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderActivationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderActivationRepository.java
@@ -25,14 +25,12 @@ import java.util.Set;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface IdentityProviderActivationRepository {
+public interface IdentityProviderActivationRepository extends FindAllRepository<IdentityProviderActivation> {
     Optional<IdentityProviderActivation> findById(
         String identityProviderId,
         String referenceId,
         IdentityProviderActivationReferenceType referenceType
     ) throws TechnicalException;
-
-    Set<IdentityProviderActivation> findAll() throws TechnicalException;
 
     Set<IdentityProviderActivation> findAllByIdentityProviderId(String identityProviderId) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderRepository.java
@@ -24,14 +24,7 @@ import java.util.Set;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface IdentityProviderRepository {
-    /**
-     * List all identity providers
-     * @return all identity providers
-     * @throws TechnicalException if something goes wrong
-     */
-    Set<IdentityProvider> findAll() throws TechnicalException;
-
+public interface IdentityProviderRepository extends FindAllRepository<IdentityProvider> {
     Set<IdentityProvider> findAllByOrganizationId(String organizationId) throws TechnicalException;
 
     IdentityProvider create(IdentityProvider identityProvider) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/InvitationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/InvitationRepository.java
@@ -18,13 +18,11 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Invitation;
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface InvitationRepository extends CrudRepository<Invitation, String> {
-    Set<Invitation> findAll() throws TechnicalException;
     List<Invitation> findByReference(String referenceType, String referenceId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MembershipRepository.java
@@ -25,7 +25,7 @@ import java.util.Set;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface MembershipRepository {
+public interface MembershipRepository extends FindAllRepository<Membership> {
     Membership create(Membership membership) throws TechnicalException;
     Membership update(Membership membership) throws TechnicalException;
     void delete(String membershipId) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MetadataRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface MetadataRepository {
+public interface MetadataRepository extends FindAllRepository<Metadata> {
     Metadata create(Metadata metadata) throws TechnicalException;
 
     Metadata update(Metadata metadata) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/NotificationTemplateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/NotificationTemplateRepository.java
@@ -26,7 +26,7 @@ import java.util.Set;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface NotificationTemplateRepository {
+public interface NotificationTemplateRepository extends FindAllRepository<NotificationTemplate> {
     Optional<NotificationTemplate> findById(String id) throws TechnicalException;
 
     NotificationTemplate create(NotificationTemplate item) throws TechnicalException;
@@ -34,8 +34,6 @@ public interface NotificationTemplateRepository {
     NotificationTemplate update(NotificationTemplate item) throws TechnicalException;
 
     void delete(String id) throws TechnicalException;
-
-    Set<NotificationTemplate> findAll() throws TechnicalException;
 
     Set<NotificationTemplate> findAllByReferenceIdAndReferenceType(String referenceId, NotificationTemplateReferenceType referenceType)
         throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/OrganizationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/OrganizationRepository.java
@@ -15,14 +15,10 @@
  */
 package io.gravitee.repository.management.api;
 
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Organization;
-import java.util.Set;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface OrganizationRepository extends CrudRepository<Organization, String> {
-    Set<Organization> findAll() throws TechnicalException;
-}
+public interface OrganizationRepository extends CrudRepository<Organization, String> {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRepository.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PageRepository {
+public interface PageRepository extends FindAllRepository<Page> {
     Page create(Page page) throws TechnicalException;
 
     Page update(Page page) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRevisionRepository.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PageRevisionRepository {
+public interface PageRevisionRepository extends FindAllRepository<PageRevision> {
     Page<PageRevision> findAll(Pageable pageable) throws TechnicalException;
 
     Optional<PageRevision> findById(String pageId, int revision) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ParameterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ParameterRepository.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ParameterRepository {
+public interface ParameterRepository extends FindAllRepository<Parameter> {
     Optional<Parameter> findById(String key, String referenceId, ParameterReferenceType referenceType) throws TechnicalException;
 
     Parameter create(Parameter item) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalNotificationConfigRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PortalNotificationConfigRepository {
+public interface PortalNotificationConfigRepository extends FindAllRepository<PortalNotificationConfig> {
     PortalNotificationConfig create(PortalNotificationConfig portalNotificationConfig) throws TechnicalException;
     PortalNotificationConfig update(PortalNotificationConfig portalNotificationConfig) throws TechnicalException;
     void delete(PortalNotificationConfig portalNotificationConfig) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/QualityRuleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/QualityRuleRepository.java
@@ -15,15 +15,10 @@
  */
 package io.gravitee.repository.management.api;
 
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.QualityRule;
-import java.util.List;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface QualityRuleRepository extends CrudRepository<QualityRule, String> {
-    Set<QualityRule> findAll() throws TechnicalException;
-}
+public interface QualityRuleRepository extends CrudRepository<QualityRule, String> {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingAnswerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingAnswerRepository.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface RatingAnswerRepository {
+public interface RatingAnswerRepository extends FindAllRepository<RatingAnswer> {
     RatingAnswer create(RatingAnswer ratingAnswer) throws TechnicalException;
 
     List<RatingAnswer> findByRating(String rating) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingRepository.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface RatingRepository {
+public interface RatingRepository extends FindAllRepository<Rating> {
     Rating create(Rating rating) throws TechnicalException;
 
     Optional<Rating> findById(String id) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * @author Florent CHAMFROY (forent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface RoleRepository {
+public interface RoleRepository extends FindAllRepository<Role> {
     Optional<Role> findById(String roleId) throws TechnicalException;
 
     Role create(Role role) throws TechnicalException;
@@ -62,12 +62,6 @@ public interface RoleRepository {
      */
     Set<Role> findByScopeAndReferenceIdAndReferenceType(RoleScope scope, String referenceId, RoleReferenceType referenceType)
         throws TechnicalException;
-
-    /**
-     * @return get all roles
-     * @throws TechnicalException if something wrong happen
-     */
-    Set<Role> findAll() throws TechnicalException;
 
     Set<Role> findAllByReferenceIdAndReferenceType(String referenceId, RoleReferenceType referenceType) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ThemeRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ThemeRepository.java
@@ -16,9 +16,7 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.Dashboard;
 import io.gravitee.repository.management.model.Theme;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -26,6 +24,5 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ThemeRepository extends CrudRepository<Theme, String> {
-    Set<Theme> findAll() throws TechnicalException;
     Set<Theme> findByReferenceIdAndReferenceType(String referenceId, String referenceType) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TicketRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TicketRepository.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface TicketRepository {
+public interface TicketRepository extends FindAllRepository<Ticket> {
     Ticket create(Ticket item) throws TechnicalException;
 
     Page<Ticket> search(TicketCriteria criteria, Sortable sortable, Pageable pageable) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TokenRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TokenRepository.java
@@ -16,10 +16,8 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.*;
+import io.gravitee.repository.management.model.Token;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -27,5 +25,4 @@ import java.util.Set;
  */
 public interface TokenRepository extends CrudRepository<Token, String> {
     List<Token> findByReference(String referenceType, String referenceId) throws TechnicalException;
-    Set<Token> findAll() throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/WorkflowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/WorkflowRepository.java
@@ -18,13 +18,11 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Workflow;
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface WorkflowRepository extends CrudRepository<Workflow, String> {
-    Set<Workflow> findAll() throws TechnicalException;
     List<Workflow> findByReferenceAndType(String referenceType, String referenceId, String type) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
@@ -61,4 +61,9 @@ public class HttpApiKeyRepository extends AbstractRepository implements ApiKeyRe
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException {
         return blockingGet(post("/keys/_search", BodyCodecs.list(ApiKey.class)).send(filter));
     }
+
+    @Override
+    public Set<ApiKey> findAll() throws TechnicalException {
+        throw new IllegalStateException();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Api;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -77,5 +78,10 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
             // Ensure that an exception is thrown and managed by the caller
             throw new IllegalStateException(te);
         }
+    }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApplicationRepository.java
@@ -83,4 +83,9 @@ public class HttpApplicationRepository extends AbstractRepository implements App
     public Set<Application> findAllByEnvironment(String environmentId, ApplicationStatus... statuses) throws TechnicalException {
         throw new IllegalStateException();
     }
+
+    @Override
+    public Set<Application> findAll() throws TechnicalException {
+        throw new IllegalStateException();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpAuditRepository.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.search.AuditCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Audit;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -43,6 +44,11 @@ public class HttpAuditRepository extends AbstractRepository implements AuditRepo
 
     @Override
     public Page<Audit> search(AuditCriteria filter, Pageable pageable) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCommandRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -52,6 +53,11 @@ public class HttpCommandRepository extends AbstractRepository implements Command
 
     @Override
     public void delete(String s) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Command> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCustomUserFieldsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCustomUserFieldsRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.CustomUserField;
 import io.gravitee.repository.management.model.CustomUserFieldReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -51,8 +52,12 @@ public class HttpCustomUserFieldsRepository extends AbstractRepository implement
     }
 
     @Override
-    public List<CustomUserField> findByReferenceIdAndReferenceType(String refId, CustomUserFieldReferenceType refType)
-        throws TechnicalException {
+    public List<CustomUserField> findByReferenceIdAndReferenceType(String refId, CustomUserFieldReferenceType refType) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<CustomUserField> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpEventRepository.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.model.Event;
 import io.vertx.ext.web.codec.BodyCodec;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -92,5 +93,10 @@ public class HttpEventRepository extends AbstractRepository implements EventRepo
             // Ensure that an exception is thrown and managed by the caller
             throw new IllegalStateException(te);
         }
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpGenericNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpGenericNotificationConfigRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -51,19 +52,26 @@ public class HttpGenericNotificationConfigRepository extends AbstractRepository 
     }
 
     @Override
-    public List<GenericNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<GenericNotificationConfig> findByReferenceAndHook(
+        String hook,
+        NotificationReferenceType referenceType,
+        String referenceId
+    ) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<GenericNotificationConfig> findByReference(NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<GenericNotificationConfig> findByReference(NotificationReferenceType referenceType, String referenceId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public void deleteByConfig(String config) throws TechnicalException {
+    public void deleteByConfig(String config) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<GenericNotificationConfig> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMembershipRepository.java
@@ -141,4 +141,9 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
     ) throws TechnicalException {
         throw new IllegalStateException();
     }
+
+    @Override
+    public Set<Membership> findAll() throws TechnicalException {
+        throw new IllegalStateException();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMetadataRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.Metadata;
 import io.gravitee.repository.management.model.MetadataReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -51,18 +52,22 @@ public class HttpMetadataRepository extends AbstractRepository implements Metada
     }
 
     @Override
-    public List<Metadata> findByKeyAndReferenceType(String key, MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByKeyAndReferenceType(String key, MetadataReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Metadata> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -58,13 +59,17 @@ public class HttpPageRepository extends AbstractRepository implements PageReposi
     }
 
     @Override
-    public Integer findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, PageReferenceType referenceType)
-        throws TechnicalException {
+    public Integer findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, PageReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
     public io.gravitee.common.data.domain.Page<Page> findAll(Pageable pageable) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Page> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRevisionRepository.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.PageRevision;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -36,6 +37,7 @@ public class HttpPageRevisionRepository extends AbstractRepository implements Pa
         throw new IllegalStateException();
     }
 
+    @Override
     public Page<PageRevision> findAll(Pageable pageable) throws TechnicalException {
         throw new IllegalStateException();
     }
@@ -46,12 +48,17 @@ public class HttpPageRevisionRepository extends AbstractRepository implements Pa
     }
 
     @Override
-    public List<PageRevision> findAllByPageId(String pageId) throws TechnicalException {
+    public List<PageRevision> findAllByPageId(String pageId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<PageRevision> findLastByPageId(String pageId) throws TechnicalException {
+    public Optional<PageRevision> findLastByPageId(String pageId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<PageRevision> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpParameterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpParameterRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -51,13 +52,17 @@ public class HttpParameterRepository extends AbstractRepository implements Param
     }
 
     @Override
-    public List<Parameter> findByKeys(List<String> keys, String referenceId, ParameterReferenceType referenceType)
-        throws TechnicalException {
+    public List<Parameter> findByKeys(List<String> keys, String referenceId, ParameterReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
     public List<Parameter> findAll(String referenceId, ParameterReferenceType referenceType) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Parameter> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPlanRepository.java
@@ -60,4 +60,9 @@ public class HttpPlanRepository extends AbstractRepository implements PlanReposi
     public Set<Plan> findByApi(String apiId) throws TechnicalException {
         return blockingGet(get("/apis/" + apiId + "/plans", BodyCodecs.set(Plan.class)).send());
     }
+
+    @Override
+    public Set<Plan> findAll() throws TechnicalException {
+        throw new IllegalStateException();
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationConfigRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.PortalNotificationConfig;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -53,18 +54,22 @@ public class HttpPortalNotificationConfigRepository extends AbstractRepository i
     }
 
     @Override
-    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public void deleteByUser(String user) throws TechnicalException {
+    public void deleteByUser(String user) {
         throw new IllegalStateException();
     }
 
     @Override
-    public void deleteReference(NotificationReferenceType referenceType, String referenceId) throws TechnicalException {
+    public void deleteReference(NotificationReferenceType referenceType, String referenceId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<PortalNotificationConfig> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationRepository.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.PortalNotificationRepository;
 import io.gravitee.repository.management.model.PortalNotification;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -40,7 +41,7 @@ public class HttpPortalNotificationRepository extends AbstractRepository impleme
     }
 
     @Override
-    public List<PortalNotification> findByUser(String user) throws TechnicalException {
+    public List<PortalNotification> findByUser(String user) {
         throw new IllegalStateException();
     }
 
@@ -50,12 +51,17 @@ public class HttpPortalNotificationRepository extends AbstractRepository impleme
     }
 
     @Override
-    public void deleteAll(String user) throws TechnicalException {
+    public void deleteAll(String user) {
         throw new IllegalStateException();
     }
 
     @Override
     public Optional<PortalNotification> findById(String id) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<PortalNotification> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingAnswerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingAnswerRepository.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.RatingAnswerRepository;
 import io.gravitee.repository.management.model.RatingAnswer;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -35,7 +36,7 @@ public class HttpRatingAnswerRepository extends AbstractRepository implements Ra
     }
 
     @Override
-    public List<RatingAnswer> findByRating(String rating) throws TechnicalException {
+    public List<RatingAnswer> findByRating(String rating) {
         throw new IllegalStateException();
     }
 
@@ -51,6 +52,11 @@ public class HttpRatingAnswerRepository extends AbstractRepository implements Ra
 
     @Override
     public void delete(String id) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<RatingAnswer> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.Rating;
 import io.gravitee.repository.management.model.RatingReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -53,19 +54,26 @@ public class HttpRatingRepository extends AbstractRepository implements RatingRe
     }
 
     @Override
-    public Page<Rating> findByReferenceIdAndReferenceTypePageable(String referenceId, RatingReferenceType referenceType, Pageable pageable)
-        throws TechnicalException {
+    public Page<Rating> findByReferenceIdAndReferenceTypePageable(
+        String referenceId,
+        RatingReferenceType referenceType,
+        Pageable pageable
+    ) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<Rating> findByReferenceIdAndReferenceType(String referenceId, RatingReferenceType referenceType) throws TechnicalException {
+    public List<Rating> findByReferenceIdAndReferenceType(String referenceId, RatingReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<Rating> findByReferenceIdAndReferenceTypeAndUser(String referenceId, RatingReferenceType referenceType, String user)
-        throws TechnicalException {
+    public Optional<Rating> findByReferenceIdAndReferenceTypeAndUser(String referenceId, RatingReferenceType referenceType, String user) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Rating> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpSubscriptionRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -66,5 +67,10 @@ public class HttpSubscriptionRepository extends AbstractRepository implements Su
     @Override
     public List<Subscription> search(SubscriptionCriteria criteria) throws TechnicalException {
         return blockingGet(post("/subscriptions/_search", BodyCodecs.list(Subscription.class)).send(criteria));
+    }
+
+    @Override
+    public Set<Subscription> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpUserRepository.java
@@ -54,7 +54,7 @@ public class HttpUserRepository extends AbstractRepository implements UserReposi
     }
 
     @Override
-    public Set<User> findByIds(List<String> ids) throws TechnicalException {
+    public Set<User> findByIds(List<String> ids) {
         throw new IllegalStateException();
     }
 
@@ -64,12 +64,17 @@ public class HttpUserRepository extends AbstractRepository implements UserReposi
     }
 
     @Override
-    public Optional<User> findBySource(String source, String sourceId, String organizationId) throws TechnicalException {
+    public Optional<User> findBySource(String source, String sourceId, String organizationId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<User> findByEmail(String email, String organizationId) throws TechnicalException {
+    public Optional<User> findByEmail(String email, String organizationId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<User> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.jdbc.common;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.gravitee.repository.jdbc.datasource.NoOpDataSource;
 import io.gravitee.repository.jdbc.exception.DatabaseInitializationException;
 import java.sql.Connection;
 import java.util.Map;
@@ -148,6 +149,10 @@ public abstract class AbstractJdbcRepositoryConfiguration implements Application
         Boolean liquibase = readPropertyValue("jdbc.liquibase", Boolean.class, LIQUIBASE_ENABLED);
         if (liquibase) {
             runLiquibase(dataSource);
+        }
+
+        if (readPropertyValue("jdbc.sqlOnly", Boolean.class, false)) {
+            return new NoOpDataSource(dataSource);
         }
 
         return dataSource;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/LoggablePreparedStatement.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/LoggablePreparedStatement.java
@@ -1,0 +1,625 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.datasource;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
+import java.util.Calendar;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LoggablePreparedStatement implements PreparedStatement {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggablePreparedStatement.class);
+
+    private final PreparedStatement preparedStatement;
+
+    public LoggablePreparedStatement(PreparedStatement preparedStatement) {
+        this.preparedStatement = preparedStatement;
+    }
+
+    @Override
+    public ResultSet executeQuery() throws SQLException {
+        return preparedStatement.executeQuery();
+    }
+
+    @Override
+    public int executeUpdate() throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1; // preparedStatement.executeUpdate();
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
+        preparedStatement.setNull(parameterIndex, sqlType);
+    }
+
+    @Override
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+        preparedStatement.setBoolean(parameterIndex, x);
+    }
+
+    @Override
+    public void setByte(int parameterIndex, byte x) throws SQLException {
+        preparedStatement.setByte(parameterIndex, x);
+    }
+
+    @Override
+    public void setShort(int parameterIndex, short x) throws SQLException {
+        preparedStatement.setShort(parameterIndex, x);
+    }
+
+    @Override
+    public void setInt(int parameterIndex, int x) throws SQLException {
+        preparedStatement.setInt(parameterIndex, x);
+    }
+
+    @Override
+    public void setLong(int parameterIndex, long x) throws SQLException {
+        preparedStatement.setLong(parameterIndex, x);
+    }
+
+    @Override
+    public void setFloat(int parameterIndex, float x) throws SQLException {
+        preparedStatement.setFloat(parameterIndex, x);
+    }
+
+    @Override
+    public void setDouble(int parameterIndex, double x) throws SQLException {
+        preparedStatement.setDouble(parameterIndex, x);
+    }
+
+    @Override
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+        preparedStatement.setBigDecimal(parameterIndex, x);
+    }
+
+    @Override
+    public void setString(int parameterIndex, String x) throws SQLException {
+        preparedStatement.setString(parameterIndex, x);
+    }
+
+    @Override
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+        preparedStatement.setBytes(parameterIndex, x);
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x) throws SQLException {
+        preparedStatement.setDate(parameterIndex, x);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x) throws SQLException {
+        preparedStatement.setTime(parameterIndex, x);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+        preparedStatement.setTimestamp(parameterIndex, x);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        preparedStatement.setAsciiStream(parameterIndex, x, length);
+    }
+
+    @Override
+    @Deprecated(since = "1.2")
+    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        preparedStatement.setUnicodeStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        preparedStatement.setBinaryStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void clearParameters() throws SQLException {
+        preparedStatement.clearParameters();
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x);
+    }
+
+    @Override
+    public boolean execute() throws SQLException {
+        return preparedStatement.execute();
+    }
+
+    @Override
+    public void addBatch() throws SQLException {
+        preparedStatement.addBatch();
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
+        preparedStatement.setCharacterStream(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setRef(int parameterIndex, Ref x) throws SQLException {
+        preparedStatement.setRef(parameterIndex, x);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, Blob x) throws SQLException {
+        preparedStatement.setBlob(parameterIndex, x);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Clob x) throws SQLException {
+        preparedStatement.setClob(parameterIndex, x);
+    }
+
+    @Override
+    public void setArray(int parameterIndex, Array x) throws SQLException {
+        preparedStatement.setArray(parameterIndex, x);
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        return preparedStatement.getMetaData();
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+        preparedStatement.setDate(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+        preparedStatement.setTime(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+        preparedStatement.setTimestamp(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+        preparedStatement.setNull(parameterIndex, sqlType, typeName);
+    }
+
+    @Override
+    public void setURL(int parameterIndex, URL x) throws SQLException {
+        preparedStatement.setURL(parameterIndex, x);
+    }
+
+    @Override
+    public ParameterMetaData getParameterMetaData() throws SQLException {
+        return preparedStatement.getParameterMetaData();
+    }
+
+    @Override
+    public void setRowId(int parameterIndex, RowId x) throws SQLException {
+        preparedStatement.setRowId(parameterIndex, x);
+    }
+
+    @Override
+    public void setNString(int parameterIndex, String value) throws SQLException {
+        preparedStatement.setNString(parameterIndex, value);
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
+        preparedStatement.setNCharacterStream(parameterIndex, value, length);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, NClob value) throws SQLException {
+        preparedStatement.setNClob(parameterIndex, value);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        preparedStatement.setClob(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+        preparedStatement.setBlob(parameterIndex, inputStream, length);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        preparedStatement.setNClob(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+        preparedStatement.setSQLXML(parameterIndex, xmlObject);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        preparedStatement.setAsciiStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        preparedStatement.setBinaryStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
+        preparedStatement.setCharacterStream(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+        preparedStatement.setAsciiStream(parameterIndex, x);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+        preparedStatement.setBinaryStream(parameterIndex, x);
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+        preparedStatement.setCharacterStream(parameterIndex, reader);
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+        preparedStatement.setNCharacterStream(parameterIndex, value);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader reader) throws SQLException {
+        preparedStatement.setClob(parameterIndex, reader);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+        preparedStatement.setBlob(parameterIndex, inputStream);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+        preparedStatement.setNClob(parameterIndex, reader);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType);
+    }
+
+    @Override
+    public long executeLargeUpdate() throws SQLException {
+        return preparedStatement.executeLargeUpdate();
+    }
+
+    @Override
+    public ResultSet executeQuery(String sql) throws SQLException {
+        return preparedStatement.executeQuery(sql);
+    }
+
+    @Override
+    public int executeUpdate(String sql) throws SQLException {
+        return preparedStatement.executeUpdate(sql);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        preparedStatement.close();
+    }
+
+    @Override
+    public int getMaxFieldSize() throws SQLException {
+        return preparedStatement.getMaxFieldSize();
+    }
+
+    @Override
+    public void setMaxFieldSize(int max) throws SQLException {
+        preparedStatement.setMaxFieldSize(max);
+    }
+
+    @Override
+    public int getMaxRows() throws SQLException {
+        return preparedStatement.getMaxRows();
+    }
+
+    @Override
+    public void setMaxRows(int max) throws SQLException {
+        preparedStatement.setMaxRows(max);
+    }
+
+    @Override
+    public void setEscapeProcessing(boolean enable) throws SQLException {
+        preparedStatement.setEscapeProcessing(enable);
+    }
+
+    @Override
+    public int getQueryTimeout() throws SQLException {
+        return preparedStatement.getQueryTimeout();
+    }
+
+    @Override
+    public void setQueryTimeout(int seconds) throws SQLException {
+        preparedStatement.setQueryTimeout(seconds);
+    }
+
+    @Override
+    public void cancel() throws SQLException {
+        preparedStatement.cancel();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return preparedStatement.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        preparedStatement.clearWarnings();
+    }
+
+    @Override
+    public void setCursorName(String name) throws SQLException {
+        preparedStatement.setCursorName(name);
+    }
+
+    @Override
+    public boolean execute(String sql) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public ResultSet getResultSet() throws SQLException {
+        return preparedStatement.getResultSet();
+    }
+
+    @Override
+    public int getUpdateCount() throws SQLException {
+        return preparedStatement.getUpdateCount();
+    }
+
+    @Override
+    public boolean getMoreResults() throws SQLException {
+        return preparedStatement.getMoreResults();
+    }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
+        preparedStatement.setFetchDirection(direction);
+    }
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        return preparedStatement.getFetchDirection();
+    }
+
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
+        preparedStatement.setFetchSize(rows);
+    }
+
+    @Override
+    public int getFetchSize() throws SQLException {
+        return preparedStatement.getFetchSize();
+    }
+
+    @Override
+    public int getResultSetConcurrency() throws SQLException {
+        return preparedStatement.getResultSetConcurrency();
+    }
+
+    @Override
+    public int getResultSetType() throws SQLException {
+        return preparedStatement.getResultSetType();
+    }
+
+    @Override
+    public void addBatch(String sql) throws SQLException {
+        preparedStatement.addBatch(sql);
+    }
+
+    @Override
+    public void clearBatch() throws SQLException {
+        preparedStatement.clearBatch();
+    }
+
+    @Override
+    public int[] executeBatch() throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return new int[] { -1 };
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return preparedStatement.getConnection();
+    }
+
+    @Override
+    public boolean getMoreResults(int current) throws SQLException {
+        return preparedStatement.getMoreResults(current);
+    }
+
+    @Override
+    public ResultSet getGeneratedKeys() throws SQLException {
+        return preparedStatement.getGeneratedKeys();
+    }
+
+    @Override
+    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1;
+    }
+
+    @Override
+    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1;
+    }
+
+    @Override
+    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1;
+    }
+
+    @Override
+    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public boolean execute(String sql, String[] columnNames) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public int getResultSetHoldability() throws SQLException {
+        return preparedStatement.getResultSetHoldability();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return preparedStatement.isClosed();
+    }
+
+    @Override
+    public void setPoolable(boolean poolable) throws SQLException {
+        preparedStatement.setPoolable(poolable);
+    }
+
+    @Override
+    public boolean isPoolable() throws SQLException {
+        return preparedStatement.isPoolable();
+    }
+
+    @Override
+    public void closeOnCompletion() throws SQLException {
+        preparedStatement.closeOnCompletion();
+    }
+
+    @Override
+    public boolean isCloseOnCompletion() throws SQLException {
+        return preparedStatement.isCloseOnCompletion();
+    }
+
+    @Override
+    public long getLargeUpdateCount() throws SQLException {
+        return preparedStatement.getLargeUpdateCount();
+    }
+
+    @Override
+    public void setLargeMaxRows(long max) throws SQLException {
+        preparedStatement.setLargeMaxRows(max);
+    }
+
+    @Override
+    public long getLargeMaxRows() throws SQLException {
+        return preparedStatement.getLargeMaxRows();
+    }
+
+    @Override
+    public long[] executeLargeBatch() throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return new long[] { -1L };
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public String enquoteLiteral(String val) throws SQLException {
+        return preparedStatement.enquoteLiteral(val);
+    }
+
+    @Override
+    public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
+        return preparedStatement.enquoteIdentifier(identifier, alwaysQuote);
+    }
+
+    @Override
+    public boolean isSimpleIdentifier(String identifier) throws SQLException {
+        return preparedStatement.isSimpleIdentifier(identifier);
+    }
+
+    @Override
+    public String enquoteNCharLiteral(String val) throws SQLException {
+        return preparedStatement.enquoteNCharLiteral(val);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return preparedStatement.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return preparedStatement.isWrapperFor(iface);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpConnection.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpConnection.java
@@ -1,0 +1,336 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.datasource;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpConnection implements Connection {
+
+    private final Connection connection;
+
+    public NoOpConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public Statement createStatement() throws SQLException {
+        return connection.createStatement();
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+        return new LoggablePreparedStatement(connection.prepareStatement(sql));
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        return connection.prepareCall(sql);
+    }
+
+    @Override
+    public String nativeSQL(String sql) throws SQLException {
+        return connection.nativeSQL(sql);
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        connection.setAutoCommit(autoCommit);
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        return connection.getAutoCommit();
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        // Do nothing
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        // Do nothing
+    }
+
+    @Override
+    public void close() throws SQLException {
+        connection.close();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return connection.isClosed();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return connection.getMetaData();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        connection.setReadOnly(readOnly);
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        return connection.isReadOnly();
+    }
+
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+        connection.setCatalog(catalog);
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+        return connection.getCatalog();
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+        connection.setTransactionIsolation(level);
+    }
+
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+        return connection.getTransactionIsolation();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return connection.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        connection.clearWarnings();
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+        return connection.createStatement(resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return connection.prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return connection.prepareCall(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        return connection.getTypeMap();
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        connection.setTypeMap(map);
+    }
+
+    @Override
+    public void setHoldability(int holdability) throws SQLException {
+        connection.setHoldability(holdability);
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        return connection.getHoldability();
+    }
+
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+        return connection.setSavepoint();
+    }
+
+    @Override
+    public Savepoint setSavepoint(String name) throws SQLException {
+        return connection.setSavepoint(name);
+    }
+
+    @Override
+    public void rollback(Savepoint savepoint) throws SQLException {
+        connection.rollback(savepoint);
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        connection.releaseSavepoint(savepoint);
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return connection.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+        throws SQLException {
+        return connection.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+        throws SQLException {
+        return connection.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+        return connection.prepareStatement(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        return connection.prepareStatement(sql, columnIndexes);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+        return connection.prepareStatement(sql, columnNames);
+    }
+
+    @Override
+    public Clob createClob() throws SQLException {
+        return connection.createClob();
+    }
+
+    @Override
+    public Blob createBlob() throws SQLException {
+        return connection.createBlob();
+    }
+
+    @Override
+    public NClob createNClob() throws SQLException {
+        return connection.createNClob();
+    }
+
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+        return connection.createSQLXML();
+    }
+
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        return connection.isValid(timeout);
+    }
+
+    @Override
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+        connection.setClientInfo(name, value);
+    }
+
+    @Override
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+        connection.setClientInfo(properties);
+    }
+
+    @Override
+    public String getClientInfo(String name) throws SQLException {
+        return connection.getClientInfo(name);
+    }
+
+    @Override
+    public Properties getClientInfo() throws SQLException {
+        return connection.getClientInfo();
+    }
+
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        return connection.createArrayOf(typeName, elements);
+    }
+
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        return connection.createStruct(typeName, attributes);
+    }
+
+    @Override
+    public void setSchema(String schema) throws SQLException {
+        connection.setSchema(schema);
+    }
+
+    @Override
+    public String getSchema() throws SQLException {
+        return connection.getSchema();
+    }
+
+    @Override
+    public void abort(Executor executor) throws SQLException {
+        connection.abort(executor);
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        connection.setNetworkTimeout(executor, milliseconds);
+    }
+
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+        return connection.getNetworkTimeout();
+    }
+
+    @Override
+    public void beginRequest() throws SQLException {
+        connection.beginRequest();
+    }
+
+    @Override
+    public void endRequest() throws SQLException {
+        connection.endRequest();
+    }
+
+    @Override
+    public boolean setShardingKeyIfValid(ShardingKey shardingKey, ShardingKey superShardingKey, int timeout) throws SQLException {
+        return connection.setShardingKeyIfValid(shardingKey, superShardingKey, timeout);
+    }
+
+    @Override
+    public boolean setShardingKeyIfValid(ShardingKey shardingKey, int timeout) throws SQLException {
+        return connection.setShardingKeyIfValid(shardingKey, timeout);
+    }
+
+    @Override
+    public void setShardingKey(ShardingKey shardingKey, ShardingKey superShardingKey) throws SQLException {
+        connection.setShardingKey(shardingKey, superShardingKey);
+    }
+
+    @Override
+    public void setShardingKey(ShardingKey shardingKey) throws SQLException {
+        connection.setShardingKey(shardingKey);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return connection.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return connection.isWrapperFor(iface);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpDataSource.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpDataSource.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.datasource;
+
+import java.io.PrintWriter;
+import java.sql.*;
+import java.util.logging.Logger;
+import javax.sql.DataSource;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpDataSource implements DataSource {
+
+    private final DataSource dataSource;
+
+    public NoOpDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return new NoOpConnection(dataSource.getConnection());
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return new NoOpConnection(dataSource.getConnection(username, password));
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return dataSource.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        dataSource.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        dataSource.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return dataSource.getLoginTimeout();
+    }
+
+    @Override
+    public ConnectionBuilder createConnectionBuilder() throws SQLException {
+        return dataSource.createConnectionBuilder();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return dataSource.getParentLogger();
+    }
+
+    @Override
+    public ShardingKeyBuilder createShardingKeyBuilder() throws SQLException {
+        return dataSource.createShardingKeyBuilder();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return dataSource.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return dataSource.isWrapperFor(iface);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractFindAllRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractFindAllRepository.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * @author GraviteeSource Team
+ */
+public abstract class JdbcAbstractFindAllRepository<T> extends JdbcAbstractRepository<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcAbstractFindAllRepository.class);
+
+    JdbcAbstractFindAllRepository(String tableName) {
+        super(tableName);
+    }
+
+    public Set<T> findAll() throws TechnicalException {
+        LOGGER.debug("JdbcAbstractFindAllRepository<{}>.findAll()", getOrm().getTableName());
+        try {
+            return new HashSet<>(jdbcTemplate.query(getOrm().getSelectAllSql(), getRowMapper()));
+        } catch (final Exception ex) {
+            String errorMessage = String.format("Failed to find all %s items:", getOrm().getTableName());
+            LOGGER.error(errorMessage, ex);
+            throw new TechnicalException(errorMessage, ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractRepository.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class JdbcAbstractRepository<T> extends TransactionalRepository {
+
+    private final JdbcObjectMapper<T> orm;
+    protected final String tableName;
+
+    @Autowired
+    protected JdbcTemplate jdbcTemplate;
+
+    JdbcAbstractRepository(String tableName) {
+        this.tableName = Objects.requireNonNull(tableName, "Table name not provided");
+        this.orm = buildOrm();
+    }
+
+    protected abstract JdbcObjectMapper<T> buildOrm();
+
+    protected RowMapper<T> getRowMapper() {
+        return this.orm.getRowMapper();
+    }
+
+    protected final JdbcObjectMapper<T> getOrm() {
+        return orm;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -348,4 +348,16 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
         }
         return apis;
     }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        LOGGER.debug("JdbcApiRepository.findAll()");
+        try {
+            return new HashSet<>(jdbcTemplate.query(ORM.getSelectAllSql(), ORM.getRowMapper()));
+        } catch (final Exception ex) {
+            final String error = "Failed to find all api";
+            LOGGER.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
@@ -266,4 +266,9 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
         }
         return started;
     }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
@@ -28,6 +28,7 @@ import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.sql.*;
@@ -335,5 +336,10 @@ public class JdbcEventRepository extends JdbcAbstractPageableRepository<Event> i
             filter.getTypes() +
             " }"
         );
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAlertEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAlertEventRepository.java
@@ -23,9 +23,12 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.AlertEvent;
 import io.gravitee.repository.mongodb.management.internal.api.AlertEventMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.AlertEventMongo;
+import io.gravitee.repository.mongodb.management.internal.model.AlertTriggerMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -122,5 +125,14 @@ public class MongoAlertEventRepository implements AlertEventRepository {
             (int) alertEventsMongo.getPageElements(),
             alertEventsMongo.getTotalElements()
         );
+    }
+
+    @Override
+    public Set<AlertEvent> findAll() throws TechnicalException {
+        return internalAlertEventRepo
+            .findAll()
+            .stream()
+            .map(alertEventMongo -> mapper.map(alertEventMongo, AlertEvent.class))
+            .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
@@ -92,4 +92,9 @@ public class MongoApiKeyRepository implements ApiKeyRepository {
 
         return (apiKey != null) ? Optional.of(mapper.map(apiKey, ApiKey.class)) : Optional.empty();
     }
+
+    @Override
+    public Set<ApiKey> findAll() throws TechnicalException {
+        return internalApiKeyRepo.findAll().stream().map(apiKeyMongo -> mapper.map(apiKeyMongo, ApiKey.class)).collect(Collectors.toSet());
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiQualityRuleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiQualityRuleRepository.java
@@ -20,18 +20,16 @@ import static java.util.stream.Collectors.toList;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
-import io.gravitee.repository.management.api.QualityRuleRepository;
-import io.gravitee.repository.management.model.Api;
-import io.gravitee.repository.management.model.ApiQualityRule;
+import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.management.model.ApiQualityRule;
 import io.gravitee.repository.mongodb.management.internal.model.ApiQualityRuleMongo;
 import io.gravitee.repository.mongodb.management.internal.model.ApiQualityRulePkMongo;
-import io.gravitee.repository.mongodb.management.internal.model.QualityRuleMongo;
 import io.gravitee.repository.mongodb.management.internal.quality.ApiQualityRuleMongoRepository;
-import io.gravitee.repository.mongodb.management.internal.quality.QualityRuleMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -125,13 +123,13 @@ public class MongoApiQualityRuleRepository implements ApiQualityRuleRepository {
     }
 
     @Override
-    public List<ApiQualityRule> findByApi(String api) throws TechnicalException {
+    public List<ApiQualityRule> findByApi(String api) {
         final List<ApiQualityRuleMongo> apiQualityRules = internalApiQualityRuleRepo.findByIdApi(api);
         return apiQualityRules.stream().map(apiQualityRuleMongo -> mapper.map(apiQualityRuleMongo, ApiQualityRule.class)).collect(toList());
     }
 
     @Override
-    public List<ApiQualityRule> findByQualityRule(String qualityRule) throws TechnicalException {
+    public List<ApiQualityRule> findByQualityRule(String qualityRule) {
         final List<ApiQualityRuleMongo> apiQualityRules = internalApiQualityRuleRepo.findByIdQualityRule(qualityRule);
         return apiQualityRules.stream().map(apiQualityRuleMongo -> mapper.map(apiQualityRuleMongo, ApiQualityRule.class)).collect(toList());
     }
@@ -156,5 +154,14 @@ public class MongoApiQualityRuleRepository implements ApiQualityRuleRepository {
             LOGGER.error(error, e);
             throw new TechnicalException(error);
         }
+    }
+
+    @Override
+    public Set<ApiQualityRule> findAll() throws TechnicalException {
+        return internalApiQualityRuleRepo
+            .findAll()
+            .stream()
+            .map(apiQualityRuleMongo -> mapper.map(apiQualityRuleMongo, ApiQualityRule.class))
+            .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -27,6 +27,8 @@ import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -106,5 +108,10 @@ public class MongoApiRepository implements ApiRepository {
 
     private Api mapApi(ApiMongo apiMongo) {
         return (apiMongo == null) ? null : mapper.map(apiMongo, Api.class);
+    }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        return internalApiRepo.findAll().stream().map(this::mapApi).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
@@ -152,4 +152,9 @@ public class MongoApplicationRepository implements ApplicationRepository {
             return mapApplications(internalApplicationRepo.findAllByEnvironmentId(environmentId));
         }
     }
+
+    @Override
+    public Set<Application> findAll() throws TechnicalException {
+        return internalApplicationRepo.findAll().stream().map(this::mapApplication).collect(Collectors.toSet());
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAuditRepository.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.mongodb.management.internal.model.AuditMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,8 +74,13 @@ public class MongoAuditRepository implements AuditRepository {
 
         Audit res = mapper.map(createdAuditMongo, Audit.class);
 
-        LOGGER.debug("Create audit [{}] - Done", audit.toString());
+        LOGGER.debug("Create audit [{}] - Done", audit);
 
         return res;
+    }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCommandRepository.java
@@ -24,6 +24,8 @@ import io.gravitee.repository.mongodb.management.internal.model.CommandMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -103,5 +105,14 @@ public class MongoCommandRepository implements CommandRepository {
         logger.debug("Search Command [{}]", criteria);
         List<CommandMongo> result = internalMessageRepo.search(criteria);
         return mapper.collection2list(result, CommandMongo.class, Command.class);
+    }
+
+    @Override
+    public Set<Command> findAll() throws TechnicalException {
+        return internalMessageRepo
+            .findAll()
+            .stream()
+            .map(commandMongo -> mapper.map(commandMongo, Command.class))
+            .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCustomUserFieldsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCustomUserFieldsRepository.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.mongodb.management.internal.user.CustomUserFieldsM
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +71,7 @@ public class MongoCustomUserFieldsRepository implements CustomUserFieldsReposito
             field.getReferenceType().name()
         );
         final Optional<CustomUserFieldMongo> previousField = internalMongoRepo.findById(id);
-        if (!previousField.isPresent()) {
+        if (previousField.isEmpty()) {
             throw new IllegalStateException(String.format("No CustomUserField found with id [%s]", id));
         }
 
@@ -109,5 +110,14 @@ public class MongoCustomUserFieldsRepository implements CustomUserFieldsReposito
 
         logger.debug("Find CustomUserField by Reference [{}/{}] - Done", refId, referenceType);
         return fields.stream().map(f -> mapper.map(f, CustomUserField.class)).collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<CustomUserField> findAll() throws TechnicalException {
+        return internalMongoRepo
+            .findAll()
+            .stream()
+            .map(customUserFieldMongo -> mapper.map(customUserFieldMongo, CustomUserField.class))
+            .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEventRepository.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.mongodb.management.internal.model.EventMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MongoEventRepository implements EventRepository {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private EventMongoRepository internalEventRepo;
@@ -163,5 +164,10 @@ public class MongoEventRepository implements EventRepository {
         event.setUpdatedAt(eventMongo.getUpdatedAt());
 
         return event;
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGenericNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGenericNotificationConfigRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.mongodb.management.internal.model.GenericNotificat
 import io.gravitee.repository.mongodb.management.internal.notification.GenericNotificationConfigMongoRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,8 +86,11 @@ public class MongoGenericNotificationConfigRepository implements GenericNotifica
     }
 
     @Override
-    public List<GenericNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<GenericNotificationConfig> findByReferenceAndHook(
+        String hook,
+        NotificationReferenceType referenceType,
+        String referenceId
+    ) {
         LOGGER.debug("Find GenericNotificationConfig [{}, {}, {}]", hook, referenceType, referenceId);
         return internalRepo
             .findByReferenceAndHook(hook, referenceType.name(), referenceId)
@@ -103,7 +107,7 @@ public class MongoGenericNotificationConfigRepository implements GenericNotifica
     }
 
     @Override
-    public void deleteByConfig(String config) throws TechnicalException {
+    public void deleteByConfig(String config) {
         LOGGER.debug("Delete GenericNotificationConfig by config [{}]", config);
         internalRepo.deleteByConfig(config);
     }
@@ -138,5 +142,10 @@ public class MongoGenericNotificationConfigRepository implements GenericNotifica
         cfg.setUpdatedAt(mongo.getUpdatedAt());
 
         return cfg;
+    }
+
+    @Override
+    public Set<GenericNotificationConfig> findAll() throws TechnicalException {
+        return internalRepo.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
@@ -22,7 +22,9 @@ import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
 import io.gravitee.repository.mongodb.management.internal.membership.MembershipMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.MembershipMongo;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,7 +112,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public void deleteMembers(MembershipReferenceType referenceType, String referenceId) throws TechnicalException {
+    public void deleteMembers(MembershipReferenceType referenceType, String referenceId) {
         logger.debug("Delete memberships [{}, {}]", referenceType, referenceId);
         internalMembershipRepo.deleteByRef(referenceType.name(), referenceId);
         logger.debug("Delete memberships [{}, {}] - Done", referenceType, referenceId);
@@ -127,7 +129,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByIds(Set<String> membershipIds) throws TechnicalException {
+    public Set<Membership> findByIds(Set<String> membershipIds) {
         logger.debug("Find membership by IDs [{}]", membershipIds);
 
         Set<Membership> memberships = internalMembershipRepo.findByIds(membershipIds).stream().map(this::map).collect(Collectors.toSet());
@@ -137,8 +139,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByReferenceAndRoleId(MembershipReferenceType referenceType, String referenceId, String roleId)
-        throws TechnicalException {
+    public Set<Membership> findByReferenceAndRoleId(MembershipReferenceType referenceType, String referenceId, String roleId) {
         logger.debug("Find membership by reference and roleId [{}, {}, {}]", referenceType, referenceId, roleId);
         Set<MembershipMongo> membershipMongos;
         if (roleId == null) {
@@ -152,8 +153,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByReferencesAndRoleId(MembershipReferenceType referenceType, List<String> referenceIds, String roleId)
-        throws TechnicalException {
+    public Set<Membership> findByReferencesAndRoleId(MembershipReferenceType referenceType, List<String> referenceIds, String roleId) {
         logger.debug("Find membership by references and roleId [{}, {}, {}]", referenceType, referenceIds, roleId);
         Set<MembershipMongo> membershipMongos;
         if (roleId == null) {
@@ -171,7 +171,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         String memberId,
         MembershipMemberType memberType,
         MembershipReferenceType referenceType
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by user and referenceType [{}, {}, {}]", memberId, memberType, referenceType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberTypeAndReferenceType(memberId, memberType.name(), referenceType.name())
@@ -183,7 +183,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByRoleId(String roleId) throws TechnicalException {
+    public Set<Membership> findByRoleId(String roleId) {
         logger.debug("Find membership by roleId [{}]", roleId);
         Set<Membership> memberships = internalMembershipRepo.findByRoleId(roleId).stream().map(this::map).collect(Collectors.toSet());
         logger.debug("Find membership by roleId [{}] = {}", roleId, memberships);
@@ -196,7 +196,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String roleId
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by user and referenceType and roleId [{}, {}, {}, {}]", memberId, memberType, referenceType, roleId);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberTypeAndReferenceTypeAndRoleId(memberId, memberType.name(), referenceType.name(), roleId)
@@ -220,7 +220,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String sourceId
-    ) throws TechnicalException {
+    ) {
         logger.debug(
             "Find membership by user and referenceType and sourceId [{}, {}, {}, {}]",
             memberId,
@@ -251,7 +251,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipReferenceType referenceType,
         String referenceId,
         String roleId
-    ) throws TechnicalException {
+    ) {
         logger.debug(
             "Find membership by user and referenceType and referenceId and roleId [{}, {}, {}, {}, {}]",
             memberId,
@@ -284,7 +284,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByMemberIdAndMemberType(String memberId, MembershipMemberType memberType) throws TechnicalException {
+    public Set<Membership> findByMemberIdAndMemberType(String memberId, MembershipMemberType memberType) {
         logger.debug("Find membership by user [{}, {}]", memberId, memberType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberType(memberId, memberType.name())
@@ -300,7 +300,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         List<String> memberIds,
         MembershipMemberType memberType,
         MembershipReferenceType referenceType
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by members and reference type [{}, {}, {}]", memberIds, memberType, referenceType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdsAndMemberTypeAndReferenceType(memberIds, memberType.name(), referenceType.name())
@@ -317,7 +317,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String referenceId
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by member and reference [{}, {}, {}, {}]", memberId, memberType, referenceId, referenceType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(memberId, memberType.name(), referenceType.name(), referenceId)
@@ -360,5 +360,10 @@ public class MongoMembershipRepository implements MembershipRepository {
         membershipMongo.setCreatedAt(membership.getCreatedAt());
         membershipMongo.setUpdatedAt(membership.getUpdatedAt());
         return membershipMongo;
+    }
+
+    @Override
+    public Set<Membership> findAll() throws TechnicalException {
+        return internalMembershipRepo.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMetadataRepository.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.mongodb.management.internal.model.MetadataMongo;
 import io.gravitee.repository.mongodb.management.internal.model.MetadataPkMongo;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +104,7 @@ public class MongoMetadataRepository implements MetadataRepository {
     }
 
     @Override
-    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) {
         LOGGER.debug("Find metadata by ref type '{}'", referenceType);
 
         final List<MetadataMongo> metadata = internalMetadataRepository.findByIdReferenceType(referenceType);
@@ -113,8 +114,7 @@ public class MongoMetadataRepository implements MetadataRepository {
     }
 
     @Override
-    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId) {
         LOGGER.debug("Find metadata by ref type '{}'", referenceType);
 
         final List<MetadataMongo> metadata = internalMetadataRepository.findByIdReferenceTypeAndIdReferenceId(referenceType, referenceId);
@@ -124,7 +124,7 @@ public class MongoMetadataRepository implements MetadataRepository {
     }
 
     @Override
-    public List<Metadata> findByKeyAndReferenceType(final String key, final MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByKeyAndReferenceType(final String key, final MetadataReferenceType referenceType) {
         LOGGER.debug("Find metadata by key '{}' and ref type '{}'", key, referenceType);
 
         final List<MetadataMongo> metadata = internalMetadataRepository.findByIdKeyAndIdReferenceType(key, referenceType);
@@ -158,5 +158,10 @@ public class MongoMetadataRepository implements MetadataRepository {
         metadataMongo.setCreatedAt(metadata.getCreatedAt());
         metadataMongo.setUpdatedAt(metadata.getUpdatedAt());
         return metadataMongo;
+    }
+
+    @Override
+    public Set<Metadata> findAll() throws TechnicalException {
+        return internalMetadataRepository.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRepository.java
@@ -30,6 +30,7 @@ import io.gravitee.repository.mongodb.management.internal.page.PageMongoReposito
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,8 +130,8 @@ public class MongoPageRepository implements PageRepository {
             PageMongo pageMongoUpdated = internalPageRepo.save(pageMongo);
             return mapper.map(pageMongoUpdated, Page.class);
         } catch (Exception e) {
-            logger.error("An error occured when updating page", e);
-            throw new TechnicalException("An error occured when updating page");
+            logger.error("An error occurred when updating page", e);
+            throw new TechnicalException("An error occurred when updating page");
         }
     }
 
@@ -139,8 +140,8 @@ public class MongoPageRepository implements PageRepository {
         try {
             internalPageRepo.deleteById(pageId);
         } catch (Exception e) {
-            logger.error("An error occured when deleting page [{}]", pageId, e);
-            throw new TechnicalException("An error occured when deleting page");
+            logger.error("An error occurred when deleting page [{}]", pageId, e);
+            throw new TechnicalException("An error occurred when deleting page");
         }
     }
 
@@ -150,8 +151,8 @@ public class MongoPageRepository implements PageRepository {
         try {
             return internalPageRepo.findMaxPageReferenceIdAndReferenceTypeOrder(referenceId, referenceType.name());
         } catch (Exception e) {
-            logger.error("An error occured when searching max order page for reference [{}, {}]", referenceId, referenceType, e);
-            throw new TechnicalException("An error occured when searching max order page for reference");
+            logger.error("An error occurred when searching max order page for reference [{}, {}]", referenceId, referenceType, e);
+            throw new TechnicalException("An error occurred when searching max order page for reference");
         }
     }
 
@@ -160,12 +161,7 @@ public class MongoPageRepository implements PageRepository {
         try {
             io.gravitee.common.data.domain.Page<PageMongo> page = internalPageRepo.findAll(pageable);
             List<Page> pageItems = mapper.collection2list(page.getContent(), PageMongo.class, Page.class);
-            return new io.gravitee.common.data.domain.Page<Page>(
-                pageItems,
-                page.getPageNumber(),
-                pageItems.size(),
-                page.getTotalElements()
-            );
+            return new io.gravitee.common.data.domain.Page<>(pageItems, page.getPageNumber(), pageItems.size(), page.getTotalElements());
         } catch (Exception e) {
             logger.error("An error occurred when searching all pages", e);
             throw new TechnicalException("An error occurred when searching all pages");
@@ -192,5 +188,10 @@ public class MongoPageRepository implements PageRepository {
                 }
             )
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<Page> findAll() throws TechnicalException {
+        return internalPageRepo.findAll().stream().map(pageMongo -> mapper.map(pageMongo, Page.class)).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRevisionRepository.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.mongodb.management.internal.page.revision.PageRevi
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,5 +109,14 @@ public class MongoPageRevisionRepository implements PageRevisionRepository {
             logger.error("An error occurred when querying last revision for page [{}]", pageId, e);
             throw new TechnicalException("An error occurred when querying the last page revision");
         }
+    }
+
+    @Override
+    public Set<PageRevision> findAll() throws TechnicalException {
+        return internalPageRevisionRepo
+            .findAll()
+            .stream()
+            .map(pageRevisionMongo -> mapper.map(pageRevisionMongo, PageRevision.class))
+            .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoParameterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoParameterRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.mongodb.management.internal.model.ParameterMongo;
 import io.gravitee.repository.mongodb.management.internal.model.ParameterPkMongo;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.slf4j.Logger;
@@ -55,8 +56,7 @@ public class MongoParameterRepository implements ParameterRepository {
     }
 
     @Override
-    public List<Parameter> findByKeys(List<String> keys, String referenceId, ParameterReferenceType referenceType)
-        throws TechnicalException {
+    public List<Parameter> findByKeys(List<String> keys, String referenceId, ParameterReferenceType referenceType) {
         LOGGER.debug("Find parameters by keys [{}]", keys);
         List<ParameterPkMongo> pkList = keys
             .stream()
@@ -64,7 +64,7 @@ public class MongoParameterRepository implements ParameterRepository {
             .collect(Collectors.toList());
         Iterable<ParameterMongo> all = internalParameterRepo.findAllById(pkList);
         LOGGER.debug("Find parameters by keys [{}] - Done", keys);
-        return StreamSupport.stream(all.spliterator(), false).map(parameter -> map(parameter)).collect(Collectors.toList());
+        return StreamSupport.stream(all.spliterator(), false).map(this::map).collect(Collectors.toList());
     }
 
     @Override
@@ -93,8 +93,8 @@ public class MongoParameterRepository implements ParameterRepository {
             ParameterMongo parameterMongoUpdated = internalParameterRepo.save(parameterMongo);
             return map(parameterMongoUpdated);
         } catch (Exception e) {
-            LOGGER.error("An error occured when updating parameter", e);
-            throw new TechnicalException("An error occured when updating parameter");
+            LOGGER.error("An error occurred when updating parameter", e);
+            throw new TechnicalException("An error occurred when updating parameter");
         }
     }
 
@@ -103,8 +103,8 @@ public class MongoParameterRepository implements ParameterRepository {
         try {
             internalParameterRepo.deleteById(new ParameterPkMongo(parameterKey, referenceId, referenceType.name()));
         } catch (Exception e) {
-            LOGGER.error("An error occured when deleting parameter [{}]", parameterKey, e);
-            throw new TechnicalException("An error occured when deleting parameter");
+            LOGGER.error("An error occurred when deleting parameter [{}]", parameterKey, e);
+            throw new TechnicalException("An error occurred when deleting parameter");
         }
     }
 
@@ -114,7 +114,7 @@ public class MongoParameterRepository implements ParameterRepository {
         Iterable<ParameterMongo> all = internalParameterRepo.findAll(referenceId, referenceType.name());
 
         LOGGER.debug("Find parameters by keys and env - Done");
-        return StreamSupport.stream(all.spliterator(), false).map(parameter -> map(parameter)).collect(Collectors.toList());
+        return StreamSupport.stream(all.spliterator(), false).map(this::map).collect(Collectors.toList());
     }
 
     private Parameter map(final ParameterMongo parameterMongo) {
@@ -134,5 +134,10 @@ public class MongoParameterRepository implements ParameterRepository {
         parameterMongo.setId(new ParameterPkMongo(parameter.getKey(), parameter.getReferenceId(), parameter.getReferenceType().name()));
         parameterMongo.setValue(parameter.getValue());
         return parameterMongo;
+    }
+
+    @Override
+    public Set<Parameter> findAll() throws TechnicalException {
+        return internalParameterRepo.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
@@ -42,12 +42,12 @@ public class MongoPlanRepository implements PlanRepository {
     private PlanMongoRepository internalPlanRepository;
 
     @Override
-    public List<Plan> findByApis(List<String> apiIds) throws TechnicalException {
+    public List<Plan> findByApis(List<String> apiIds) {
         return internalPlanRepository.findByApiIn(apiIds).stream().map(this::map).collect(Collectors.toList());
     }
 
     @Override
-    public Set<Plan> findByApi(String apiId) throws TechnicalException {
+    public Set<Plan> findByApi(String apiId) {
         return internalPlanRepository.findByApi(apiId).stream().map(this::map).collect(Collectors.toSet());
     }
 
@@ -92,5 +92,10 @@ public class MongoPlanRepository implements PlanRepository {
 
     private Plan map(PlanMongo planMongo) {
         return (planMongo == null) ? null : mapper.map(planMongo, Plan.class);
+    }
+
+    @Override
+    public Set<Plan> findAll() throws TechnicalException {
+        return internalPlanRepository.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationConfigRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.mongodb.management.internal.model.PortalNotificati
 import io.gravitee.repository.mongodb.management.internal.notification.PortalNotificationConfigMongoRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,8 +82,7 @@ public class MongoPortalNotificationConfigRepository implements PortalNotificati
     }
 
     @Override
-    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId) {
         LOGGER.debug("Find PortalNotificationConfigs [{}, {}, {}]", hook, referenceType, referenceId);
         return internalRepo
             .findByReferenceAndHook(hook, referenceType.name(), referenceId)
@@ -92,13 +92,13 @@ public class MongoPortalNotificationConfigRepository implements PortalNotificati
     }
 
     @Override
-    public void deleteByUser(String user) throws TechnicalException {
+    public void deleteByUser(String user) {
         LOGGER.debug("Delete PortalNotificationConfigs [{}]", user);
         internalRepo.deleteByUser(user);
     }
 
     @Override
-    public void deleteReference(NotificationReferenceType referenceType, String referenceId) throws TechnicalException {
+    public void deleteReference(NotificationReferenceType referenceType, String referenceId) {
         LOGGER.debug("Delete PortalNotificationConfigs [{}, {}]", referenceType, referenceId);
         internalRepo.deleteByReference(referenceType.name(), referenceId);
     }
@@ -129,5 +129,10 @@ public class MongoPortalNotificationConfigRepository implements PortalNotificati
         cfg.setUpdatedAt(mongo.getUpdatedAt());
 
         return cfg;
+    }
+
+    @Override
+    public Set<PortalNotificationConfig> findAll() throws TechnicalException {
+        return internalRepo.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationRepository.java
@@ -17,14 +17,13 @@ package io.gravitee.repository.mongodb.management;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNotificationRepository;
-import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.PortalNotification;
-import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.management.internal.model.PortalNotificationMongo;
 import io.gravitee.repository.mongodb.management.internal.notification.PortalNotificationMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +46,7 @@ public class MongoPortalNotificationRepository implements PortalNotificationRepo
     private GraviteeMapper mapper;
 
     @Override
-    public List<PortalNotification> findByUser(String user) throws TechnicalException {
+    public List<PortalNotification> findByUser(String user) {
         LOGGER.debug("Find notifications by user: {}", user);
         return internalRepo.findByUser(user).stream().map(n -> mapper.map(n, PortalNotification.class)).collect(Collectors.toList());
     }
@@ -86,8 +85,13 @@ public class MongoPortalNotificationRepository implements PortalNotificationRepo
     }
 
     @Override
-    public void deleteAll(String user) throws TechnicalException {
+    public void deleteAll(String user) {
         LOGGER.debug("Delete notification for user : {}", user);
         internalRepo.deleteAll(user);
+    }
+
+    @Override
+    public Set<PortalNotification> findAll() throws TechnicalException {
+        return internalRepo.findAll().stream().map(this::mapPortalNotification).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingAnswerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingAnswerRepository.java
@@ -25,6 +25,8 @@ import io.gravitee.repository.mongodb.management.internal.api.RatingAnswerMongoR
 import io.gravitee.repository.mongodb.management.internal.model.RatingAnswerMongo;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -119,5 +121,10 @@ public class MongoRatingAnswerRepository implements RatingAnswerRepository {
         ratingAnswerMongo.setComment(ratingAnswer.getComment());
         ratingAnswerMongo.setCreatedAt(ratingAnswer.getCreatedAt());
         return ratingAnswerMongo;
+    }
+
+    @Override
+    public Set<RatingAnswer> findAll() throws TechnicalException {
+        return internalRatingAnswerRepository.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingRepository.java
@@ -28,6 +28,8 @@ import io.gravitee.repository.mongodb.management.internal.api.RatingMongoReposit
 import io.gravitee.repository.mongodb.management.internal.model.RatingMongo;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +62,7 @@ public class MongoRatingRepository implements RatingRepository {
         final String referenceId,
         final RatingReferenceType referenceType,
         final String user
-    ) throws TechnicalException {
+    ) {
         LOGGER.debug("Find rating by ref [{}] and user [{}]", referenceId, user);
         final RatingMongo rating = internalRatingRepository.findByReferenceIdAndReferenceTypeAndUser(
             referenceId,
@@ -84,7 +86,7 @@ public class MongoRatingRepository implements RatingRepository {
         final String referenceId,
         final RatingReferenceType referenceType,
         final Pageable pageable
-    ) throws TechnicalException {
+    ) {
         LOGGER.debug("Find rating by ref [{}] with pagination", referenceId);
         final org.springframework.data.domain.Page<RatingMongo> ratingPageMongo = internalRatingRepository.findByReferenceIdAndReferenceType(
             referenceId,
@@ -173,5 +175,10 @@ public class MongoRatingRepository implements RatingRepository {
         ratingMongo.setCreatedAt(rating.getCreatedAt());
         ratingMongo.setUpdatedAt(rating.getUpdatedAt());
         return ratingMongo;
+    }
+
+    @Override
+    public Set<Rating> findAll() throws TechnicalException {
+        return internalRatingRepository.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
@@ -26,6 +26,8 @@ import io.gravitee.repository.mongodb.management.internal.plan.SubscriptionMongo
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -103,5 +105,10 @@ public class MongoSubscriptionRepository implements SubscriptionRepository {
 
     private Subscription map(SubscriptionMongo subscriptionMongo) {
         return (subscriptionMongo == null) ? null : mapper.map(subscriptionMongo, Subscription.class);
+    }
+
+    @Override
+    public Set<Subscription> findAll() throws TechnicalException {
+        return internalSubscriptionRepository.findAll().stream().map(this::map).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTicketRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTicketRepository.java
@@ -27,6 +27,8 @@ import io.gravitee.repository.mongodb.management.internal.ticket.TicketMongoRepo
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,5 +84,10 @@ public class MongoTicketRepository implements TicketRepository {
         LOGGER.debug("Search ticket {} - Done", ticketId);
 
         return Optional.ofNullable(mapper.map(ticket, Ticket.class));
+    }
+
+    @Override
+    public Set<Ticket> findAll() throws TechnicalException {
+        return internalTicketRepo.findAll().stream().map(ticketMongo -> mapper.map(ticketMongo, Ticket.class)).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,8 +42,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class MongoUserRepository implements UserRepository {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
-    private Pattern escaper = Pattern.compile("([^a-zA-z0-9])");
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Pattern escaper = Pattern.compile("([^a-zA-z0-9])");
 
     @Autowired
     private UserMongoRepository internalUserRepo;
@@ -51,7 +52,7 @@ public class MongoUserRepository implements UserRepository {
     private GraviteeMapper mapper;
 
     @Override
-    public Optional<User> findBySource(String source, String sourceId, String organizationId) throws TechnicalException {
+    public Optional<User> findBySource(String source, String sourceId, String organizationId) {
         logger.debug("Find user by name source[{}] user[{}]", source, sourceId);
 
         String escapedSourceId = escaper.matcher(sourceId).replaceAll("\\\\$1");
@@ -62,7 +63,7 @@ public class MongoUserRepository implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByEmail(String email, String organizationId) throws TechnicalException {
+    public Optional<User> findByEmail(String email, String organizationId) {
         logger.debug("Find user by email [{}]", email);
 
         UserMongo user = internalUserRepo.findByEmail(email, organizationId);
@@ -72,7 +73,7 @@ public class MongoUserRepository implements UserRepository {
     }
 
     @Override
-    public Set<User> findByIds(List<String> ids) throws TechnicalException {
+    public Set<User> findByIds(List<String> ids) {
         logger.debug("Find user by identifiers user [{}]", ids);
 
         Set<UserMongo> usersMongo = internalUserRepo.findByIds(ids);
@@ -155,5 +156,10 @@ public class MongoUserRepository implements UserRepository {
     public void delete(String id) throws TechnicalException {
         logger.debug("Delete user [{}]", id);
         internalUserRepo.deleteById(id);
+    }
+
+    @Override
+    public Set<User> findAll() throws TechnicalException {
+        return internalUserRepo.findAll().stream().map(userMongo -> mapper.map(userMongo, User.class)).collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AlertEventRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AlertEventRepositoryProxy.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.search.AlertEventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.AlertEvent;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -31,27 +32,38 @@ import org.springframework.stereotype.Component;
 @Component
 public class AlertEventRepositoryProxy extends AbstractProxy<AlertEventRepository> implements AlertEventRepository {
 
+    @Override
     public Page<AlertEvent> search(AlertEventCriteria criteria, Pageable pageable) {
         return target.search(criteria, pageable);
     }
 
+    @Override
     public void deleteAll(String alertId) {
         target.deleteAll(alertId);
     }
 
+    @Override
     public Optional<AlertEvent> findById(String s) throws TechnicalException {
         return target.findById(s);
     }
 
+    @Override
     public AlertEvent create(AlertEvent item) throws TechnicalException {
         return target.create(item);
     }
 
+    @Override
     public AlertEvent update(AlertEvent item) throws TechnicalException {
         return target.update(item);
     }
 
+    @Override
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<AlertEvent> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiKeyRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiKeyRepositoryProxy.java
@@ -56,4 +56,9 @@ public class ApiKeyRepositoryProxy extends AbstractProxy<ApiKeyRepository> imple
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException {
         return target.findByCriteria(filter);
     }
+
+    @Override
+    public Set<ApiKey> findAll() throws TechnicalException {
+        return target.findAll();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiQualityRuleRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiQualityRuleRepositoryProxy.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.model.ApiQualityRule;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,5 +68,10 @@ public class ApiQualityRuleRepositoryProxy extends AbstractProxy<ApiQualityRuleR
     @Override
     public void deleteByApi(String api) throws TechnicalException {
         target.deleteByApi(api);
+    }
+
+    @Override
+    public Set<ApiQualityRule> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -22,8 +22,10 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiQualityRule;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,5 +69,10 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     @Override
     public List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
         return target.search(apiCriteria, apiFieldExclusionFilter);
+    }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApplicationRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApplicationRepositoryProxy.java
@@ -84,4 +84,9 @@ public class ApplicationRepositoryProxy extends AbstractProxy<ApplicationReposit
     public Set<Application> findAllByEnvironment(String environment, ApplicationStatus... statuses) throws TechnicalException {
         return target.findAllByEnvironment(environment, statuses);
     }
+
+    @Override
+    public Set<Application> findAll() throws TechnicalException {
+        return target.findAll();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AuditRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AuditRepositoryProxy.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.search.AuditCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Audit;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,5 +55,10 @@ public class AuditRepositoryProxy extends AbstractProxy<AuditRepository> impleme
     @Override
     public Page<Audit> search(AuditCriteria filter, Pageable pageable) {
         return target.search(filter, pageable);
+    }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CommandRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CommandRepositoryProxy.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -53,5 +54,10 @@ public class CommandRepositoryProxy extends AbstractProxy<CommandRepository> imp
     @Override
     public List<Command> search(CommandCriteria criteria) {
         return target.search(criteria);
+    }
+
+    @Override
+    public Set<Command> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CustomUserFieldsRespositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CustomUserFieldsRespositoryProxy.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.CustomUserField;
 import io.gravitee.repository.management.model.CustomUserFieldReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,5 +55,10 @@ public class CustomUserFieldsRespositoryProxy extends AbstractProxy<CustomUserFi
     public List<CustomUserField> findByReferenceIdAndReferenceType(String refId, CustomUserFieldReferenceType refType)
         throws TechnicalException {
         return target.findByReferenceIdAndReferenceType(refId, refType);
+    }
+
+    @Override
+    public Set<CustomUserField> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/EventRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/EventRepositoryProxy.java
@@ -21,9 +21,9 @@ import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Event;
-import io.gravitee.repository.management.model.EventType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -66,5 +66,10 @@ public class EventRepositoryProxy extends AbstractProxy<EventRepository> impleme
     @Override
     public List<Event> search(EventCriteria filter) {
         return target.search(filter);
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/GenericNotificationConfigRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/GenericNotificationConfigRepositoryProxy.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,5 +68,10 @@ public class GenericNotificationConfigRepositoryProxy
     @Override
     public void deleteByConfig(String config) throws TechnicalException {
         target.deleteByConfig(config);
+    }
+
+    @Override
+    public Set<GenericNotificationConfig> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MembershipRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MembershipRepositoryProxy.java
@@ -148,4 +148,9 @@ public class MembershipRepositoryProxy extends AbstractProxy<MembershipRepositor
     ) throws TechnicalException {
         return target.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(memberId, memberType, referenceType, referenceId);
     }
+
+    @Override
+    public Set<Membership> findAll() throws TechnicalException {
+        return target.findAll();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MetadataRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MetadataRepositoryProxy.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.Metadata;
 import io.gravitee.repository.management.model.MetadataReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -64,5 +65,10 @@ public class MetadataRepositoryProxy extends AbstractProxy<MetadataRepository> i
     @Override
     public List<Metadata> findByKeyAndReferenceType(String key, MetadataReferenceType referenceType) throws TechnicalException {
         return target.findByKeyAndReferenceType(key, referenceType);
+    }
+
+    @Override
+    public Set<Metadata> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRepositoryProxy.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -68,5 +69,10 @@ public class PageRepositoryProxy extends AbstractProxy<PageRepository> implement
     @Override
     public io.gravitee.common.data.domain.Page<Page> findAll(Pageable pageable) throws TechnicalException {
         return target.findAll(pageable);
+    }
+
+    @Override
+    public Set<Page> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRevisionRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRevisionRepositoryProxy.java
@@ -17,14 +17,12 @@ package io.gravitee.rest.api.repository.proxy;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PageRevisionRepository;
-import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
-import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.repository.management.model.PageRevision;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -57,5 +55,10 @@ public class PageRevisionRepositoryProxy extends AbstractProxy<PageRevisionRepos
     @Override
     public Optional<PageRevision> findById(String pageId, int revision) throws TechnicalException {
         return target.findById(pageId, revision);
+    }
+
+    @Override
+    public Set<PageRevision> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ParameterRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ParameterRepositoryProxy.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -59,5 +60,10 @@ public class ParameterRepositoryProxy extends AbstractProxy<ParameterRepository>
     @Override
     public List<Parameter> findAll(String referenceId, ParameterReferenceType referenceType) throws TechnicalException {
         return target.findAll(referenceId, referenceType);
+    }
+
+    @Override
+    public Set<Parameter> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PlanRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PlanRepositoryProxy.java
@@ -35,23 +35,33 @@ public class PlanRepositoryProxy extends AbstractProxy<PlanRepository> implement
         return target.findByApis(apiIds);
     }
 
+    @Override
     public Set<Plan> findByApi(String apiId) throws TechnicalException {
         return target.findByApi(apiId);
     }
 
+    @Override
     public Optional<Plan> findById(String s) throws TechnicalException {
         return target.findById(s);
     }
 
+    @Override
     public Plan create(Plan item) throws TechnicalException {
         return target.create(item);
     }
 
+    @Override
     public Plan update(Plan item) throws TechnicalException {
         return target.update(item);
     }
 
+    @Override
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<Plan> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationConfigRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationConfigRepositoryProxy.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.PortalNotificationConfig;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,5 +68,10 @@ public class PortalNotificationConfigRepositoryProxy
     @Override
     public void deleteReference(NotificationReferenceType referenceType, String referenceId) throws TechnicalException {
         target.deleteReference(referenceType, referenceId);
+    }
+
+    @Override
+    public Set<PortalNotificationConfig> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationRepositoryProxy.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.PortalNotificationRepository;
 import io.gravitee.repository.management.model.PortalNotification;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -62,5 +63,10 @@ public class PortalNotificationRepositoryProxy extends AbstractProxy<PortalNotif
     @Override
     public void deleteAll(String s) throws TechnicalException {
         target.deleteAll(s);
+    }
+
+    @Override
+    public Set<PortalNotification> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingAnswerRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingAnswerRepositoryProxy.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.RatingAnswerRepository;
 import io.gravitee.repository.management.model.RatingAnswer;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -52,5 +53,10 @@ public class RatingAnswerRepositoryProxy extends AbstractProxy<RatingAnswerRepos
     @Override
     public void delete(String id) throws TechnicalException {
         target.delete(id);
+    }
+
+    @Override
+    public Set<RatingAnswer> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingRepositoryProxy.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.model.Rating;
 import io.gravitee.repository.management.model.RatingReferenceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,5 +68,10 @@ public class RatingRepositoryProxy extends AbstractProxy<RatingRepository> imple
     public Optional<Rating> findByReferenceIdAndReferenceTypeAndUser(String referenceId, RatingReferenceType referenceType, String user)
         throws TechnicalException {
         return target.findByReferenceIdAndReferenceTypeAndUser(referenceId, referenceType, user);
+    }
+
+    @Override
+    public Set<Rating> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/SubscriptionRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/SubscriptionRepositoryProxy.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -56,5 +57,10 @@ public class SubscriptionRepositoryProxy extends AbstractProxy<SubscriptionRepos
 
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<Subscription> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TicketRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TicketRepositoryProxy.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.TicketCriteria;
 import io.gravitee.repository.management.model.Ticket;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 /**
@@ -45,5 +46,10 @@ public class TicketRepositoryProxy extends AbstractProxy<TicketRepository> imple
     @Override
     public Optional<Ticket> findById(String ticketId) throws TechnicalException {
         return target.findById(ticketId);
+    }
+
+    @Override
+    public Set<Ticket> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/UserRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/UserRepositoryProxy.java
@@ -73,4 +73,9 @@ public class UserRepositoryProxy extends AbstractProxy<UserRepository> implement
     public void delete(String id) throws TechnicalException {
         target.delete(id);
     }
+
+    @Override
+    public Set<User> findAll() throws TechnicalException {
+        return target.findAll();
+    }
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6035

Add requirements for mongo->jdbc database migration tool :
- all repositories extends the findAll() function
- add the NoOpDatasource, that can be enabled with `jdbc.sqlOnly` parameter, to log SQL queries to a file

Merged to 3.5.x cause customer is in 3.5, so migration tool has to use 3.5 repository plugins.

I'll make another PR to merge that in master, as we can use the migration tool with latest repository plugins.
