### PR TITLE
Feat/mongo to JDBC in master

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AlertTriggerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AlertTriggerRepository.java
@@ -26,7 +26,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface AlertTriggerRepository extends CrudRepository<AlertTrigger, String> {
-    Set<AlertTrigger> findAll() throws TechnicalException;
 
     default List<AlertTrigger> findByReference(String referenceType, String referenceId) throws TechnicalException {
         return findByReferenceAndReferenceIds(referenceType, Arrays.asList(referenceId));

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiHeaderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiHeaderRepository.java
@@ -24,7 +24,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ApiHeaderRepository extends CrudRepository<ApiHeader, String> {
-    Set<ApiHeader> findAll() throws TechnicalException;
 
     Set<ApiHeader> findAllByEnvironment(String environmentId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.ApiKey;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -26,7 +27,7 @@ import java.util.Set;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ApiKeyRepository {
+public interface ApiKeyRepository extends FindAllRepository<ApiKey> {
     /**
      * Give the API Key detail from the given id
      *

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiQualityRuleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiQualityRuleRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ApiQualityRuleRepository {
+public interface ApiQualityRuleRepository extends FindAllRepository<ApiQualityRule> {
     Optional<ApiQualityRule> findById(String api, String qualityRule) throws TechnicalException;
     ApiQualityRule create(ApiQualityRule apiQualityRule) throws TechnicalException;
     ApiQualityRule update(ApiQualityRule apiQualityRule) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CategoryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CategoryRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Category;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -26,7 +27,7 @@ import java.util.Set;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface CategoryRepository {
+public interface CategoryRepository extends FindAllRepository<Category> {
     Optional<Category> findById(String id) throws TechnicalException;
 
     Category create(Category item) throws TechnicalException;
@@ -34,8 +35,6 @@ public interface CategoryRepository {
     Category update(Category item) throws TechnicalException;
 
     void delete(String id) throws TechnicalException;
-
-    Set<Category> findAll() throws TechnicalException;
 
     Optional<Category> findByKey(String key, String environment) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CrudRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CrudRepository.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-interface CrudRepository<T, ID> {
+interface CrudRepository<T, ID> extends FindAllRepository<T> {
     Optional<T> findById(ID id) throws TechnicalException;
 
     T create(T item) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CustomUserFieldsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/CustomUserFieldsRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface CustomUserFieldsRepository {
+public interface CustomUserFieldsRepository extends FindAllRepository<CustomUserField> {
     CustomUserField create(CustomUserField field) throws TechnicalException;
 
     CustomUserField update(CustomUserField field) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DashboardRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DashboardRepository.java
@@ -17,14 +17,14 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Dashboard;
+
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface DashboardRepository extends CrudRepository<Dashboard, String> {
-    Set<Dashboard> findAll() throws TechnicalException;
+
     List<Dashboard> findByReferenceType(String referenceType) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DictionaryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/DictionaryRepository.java
@@ -24,12 +24,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface DictionaryRepository extends CrudRepository<Dictionary, String> {
-    /**
-     * List all dictionaries
-     * @return all dictionaries
-     * @throws TechnicalException if something goes wrong
-     */
-    Set<Dictionary> findAll() throws TechnicalException;
 
     /**
      * List all dictionaries for requested environments

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/EnvironmentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/EnvironmentRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Environment;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -25,8 +26,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface EnvironmentRepository extends CrudRepository<Environment, String> {
-    Set<Environment> findAll() throws TechnicalException;
-
     Set<Environment> findByOrganization(String organizationId) throws TechnicalException;
 
     Set<Environment> findByOrganizationsAndHrids(Set<String> organizationsHrids, Set<String> hrids) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FindAllRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/FindAllRepository.java
@@ -16,15 +16,14 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.Workflow;
 
-import java.util.List;
+import java.util.Set;
 
 /**
- * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
+ * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface WorkflowRepository extends CrudRepository<Workflow, String> {
+public interface FindAllRepository<T> {
 
-    List<Workflow> findByReferenceAndType(String referenceType, String referenceId, String type) throws TechnicalException;
+    Set<T> findAll() throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GenericNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GenericNotificationConfigRepository.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface GenericNotificationConfigRepository {
+public interface GenericNotificationConfigRepository extends FindAllRepository<GenericNotificationConfig> {
     GenericNotificationConfig create(GenericNotificationConfig genericNotificationConfig) throws TechnicalException;
     GenericNotificationConfig update(GenericNotificationConfig genericNotificationConfig) throws TechnicalException;
     void delete(String id) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GroupRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/GroupRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Group;
+
 import java.util.Set;
 
 /**
@@ -24,12 +25,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface GroupRepository extends CrudRepository<Group, String> {
-    /**
-     * List all Groups
-     * @return all groups
-     * @throws TechnicalException if something goes wrong
-     */
-    Set<Group> findAll() throws TechnicalException;
 
     Set<Group> findAllByEnvironment(String environmentId) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderActivationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderActivationRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.management.api;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.IdentityProviderActivation;
 import io.gravitee.repository.management.model.IdentityProviderActivationReferenceType;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -25,14 +26,12 @@ import java.util.Set;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface IdentityProviderActivationRepository {
+public interface IdentityProviderActivationRepository extends FindAllRepository<IdentityProviderActivation> {
     Optional<IdentityProviderActivation> findById(
         String identityProviderId,
         String referenceId,
         IdentityProviderActivationReferenceType referenceType
     ) throws TechnicalException;
-
-    Set<IdentityProviderActivation> findAll() throws TechnicalException;
 
     Set<IdentityProviderActivation> findAllByIdentityProviderId(String identityProviderId) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/IdentityProviderRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.IdentityProvider;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -24,13 +25,7 @@ import java.util.Set;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface IdentityProviderRepository {
-    /**
-     * List all identity providers
-     * @return all identity providers
-     * @throws TechnicalException if something goes wrong
-     */
-    Set<IdentityProvider> findAll() throws TechnicalException;
+public interface IdentityProviderRepository extends FindAllRepository<IdentityProvider> {
 
     Set<IdentityProvider> findAllByOrganizationId(String organizationId) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/InvitationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/InvitationRepository.java
@@ -17,14 +17,14 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Invitation;
+
 import java.util.List;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface InvitationRepository extends CrudRepository<Invitation, String> {
-    Set<Invitation> findAll() throws TechnicalException;
+
     List<Invitation> findByReference(String referenceType, String referenceId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MembershipRepository.java
@@ -25,7 +25,7 @@ import java.util.Set;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface MembershipRepository {
+public interface MembershipRepository extends FindAllRepository<Membership> {
     Membership create(Membership membership) throws TechnicalException;
     Membership update(Membership membership) throws TechnicalException;
     void delete(String membershipId) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MetadataRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface MetadataRepository {
+public interface MetadataRepository extends FindAllRepository<Metadata> {
     Metadata create(Metadata metadata) throws TechnicalException;
 
     Metadata update(Metadata metadata) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/NotificationTemplateRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/NotificationTemplateRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.NotificationTemplate;
 import io.gravitee.repository.management.model.NotificationTemplateReferenceType;
 import io.gravitee.repository.management.model.NotificationTemplateType;
+
 import java.util.Optional;
 import java.util.Set;
 
@@ -26,7 +27,7 @@ import java.util.Set;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface NotificationTemplateRepository {
+public interface NotificationTemplateRepository extends FindAllRepository<NotificationTemplate> {
     Optional<NotificationTemplate> findById(String id) throws TechnicalException;
 
     NotificationTemplate create(NotificationTemplate item) throws TechnicalException;
@@ -34,8 +35,6 @@ public interface NotificationTemplateRepository {
     NotificationTemplate update(NotificationTemplate item) throws TechnicalException;
 
     void delete(String id) throws TechnicalException;
-
-    Set<NotificationTemplate> findAll() throws TechnicalException;
 
     Set<NotificationTemplate> findAllByReferenceIdAndReferenceType(String referenceId, NotificationTemplateReferenceType referenceType)
         throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/OrganizationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/OrganizationRepository.java
@@ -17,7 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Organization;
-import java.util.Collection;
+
 import java.util.Set;
 
 /**
@@ -27,5 +27,4 @@ import java.util.Set;
 public interface OrganizationRepository extends CrudRepository<Organization, String> {
     Long count() throws TechnicalException;
     Set<Organization> findByHrids(Set<String> hrids) throws TechnicalException;
-    Collection<Organization> findAll() throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRepository.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PageRepository {
+public interface PageRepository extends FindAllRepository<Page> {
     Page create(Page page) throws TechnicalException;
 
     Page update(Page page) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PageRevisionRepository.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PageRevisionRepository {
+public interface PageRevisionRepository extends FindAllRepository<PageRevision> {
     Page<PageRevision> findAll(Pageable pageable) throws TechnicalException;
 
     Optional<PageRevision> findById(String pageId, int revision) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ParameterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ParameterRepository.java
@@ -26,7 +26,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ParameterRepository {
+public interface ParameterRepository extends FindAllRepository<Parameter> {
     Optional<Parameter> findById(String key, String referenceId, ParameterReferenceType referenceType) throws TechnicalException;
 
     Parameter create(Parameter item) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalNotificationConfigRepository.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface PortalNotificationConfigRepository {
+public interface PortalNotificationConfigRepository extends FindAllRepository<PortalNotificationConfig> {
     PortalNotificationConfig create(PortalNotificationConfig portalNotificationConfig) throws TechnicalException;
     PortalNotificationConfig update(PortalNotificationConfig portalNotificationConfig) throws TechnicalException;
     void delete(PortalNotificationConfig portalNotificationConfig) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/QualityRuleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/QualityRuleRepository.java
@@ -15,15 +15,12 @@
  */
 package io.gravitee.repository.management.api;
 
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.QualityRule;
-import java.util.List;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface QualityRuleRepository extends CrudRepository<QualityRule, String> {
-    Set<QualityRule> findAll() throws TechnicalException;
+
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingAnswerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingAnswerRepository.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface RatingAnswerRepository {
+public interface RatingAnswerRepository extends FindAllRepository<RatingAnswer> {
     RatingAnswer create(RatingAnswer ratingAnswer) throws TechnicalException;
 
     List<RatingAnswer> findByRating(String rating) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RatingRepository.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface RatingRepository {
+public interface RatingRepository extends FindAllRepository<Rating> {
     Rating create(Rating rating) throws TechnicalException;
 
     Optional<Rating> findById(String id) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/RoleRepository.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * @author Florent CHAMFROY (forent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface RoleRepository {
+public interface RoleRepository extends FindAllRepository<Role> {
     Optional<Role> findById(String roleId) throws TechnicalException;
 
     Role create(Role role) throws TechnicalException;
@@ -62,12 +62,6 @@ public interface RoleRepository {
      */
     Set<Role> findByScopeAndReferenceIdAndReferenceType(RoleScope scope, String referenceId, RoleReferenceType referenceType)
         throws TechnicalException;
-
-    /**
-     * @return get all roles
-     * @throws TechnicalException if something wrong happen
-     */
-    Set<Role> findAll() throws TechnicalException;
 
     Set<Role> findAllByReferenceIdAndReferenceType(String referenceId, RoleReferenceType referenceType) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ThemeRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ThemeRepository.java
@@ -16,9 +16,8 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.Dashboard;
 import io.gravitee.repository.management.model.Theme;
-import java.util.List;
+
 import java.util.Set;
 
 /**
@@ -26,6 +25,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ThemeRepository extends CrudRepository<Theme, String> {
-    Set<Theme> findAll() throws TechnicalException;
+
     Set<Theme> findByReferenceIdAndReferenceType(String referenceId, String referenceType) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TicketRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TicketRepository.java
@@ -21,13 +21,14 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.TicketCriteria;
 import io.gravitee.repository.management.model.Ticket;
+
 import java.util.Optional;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface TicketRepository {
+public interface TicketRepository extends FindAllRepository<Ticket> {
     Ticket create(Ticket item) throws TechnicalException;
 
     Page<Ticket> search(TicketCriteria criteria, Sortable sortable, Pageable pageable) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TokenRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/TokenRepository.java
@@ -16,16 +16,15 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.model.*;
+import io.gravitee.repository.management.model.Token;
+
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface TokenRepository extends CrudRepository<Token, String> {
+
     List<Token> findByReference(String referenceType, String referenceId) throws TechnicalException;
-    Set<Token> findAll() throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
@@ -20,10 +20,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.ApiKey;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -38,7 +39,7 @@ public class HttpApiKeyRepository extends AbstractRepository implements ApiKeyRe
     }
 
     @Override
-    public List<ApiKey> findByKey(String apiKey) throws TechnicalException {
+    public List<ApiKey> findByKey(String apiKey) {
         throw new IllegalStateException();
     }
 
@@ -58,17 +59,22 @@ public class HttpApiKeyRepository extends AbstractRepository implements ApiKeyRe
     }
 
     @Override
-    public Set<ApiKey> findBySubscription(String subscription) throws TechnicalException {
+    public Set<ApiKey> findBySubscription(String subscription) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<ApiKey> findByPlan(String plan) throws TechnicalException {
+    public Set<ApiKey> findByPlan(String plan) {
         throw new IllegalStateException();
     }
 
     @Override
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException {
         return blockingGet(post("/keys/_search", BodyCodecs.list(ApiKey.class)).send(filter)).payload();
+    }
+
+    @Override
+    public Set<ApiKey> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -23,9 +23,11 @@ import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Api;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -78,5 +80,10 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
             // Ensure that an exception is thrown and managed by the caller
             throw new IllegalStateException(te);
         }
+    }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApplicationRepository.java
@@ -22,10 +22,11 @@ import io.gravitee.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -60,17 +61,17 @@ public class HttpApplicationRepository extends AbstractRepository implements App
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids) throws TechnicalException {
+    public Set<Application> findByIds(List<String> ids) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Application> findByGroups(List<String> groupIds, ApplicationStatus... statuses) throws TechnicalException {
+    public Set<Application> findByGroups(List<String> groupIds, ApplicationStatus... statuses) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Application> findAllByEnvironment(String environmentId, ApplicationStatus... statuses) throws TechnicalException {
+    public Set<Application> findAllByEnvironment(String environmentId, ApplicationStatus... statuses) {
         throw new IllegalStateException();
     }
 
@@ -82,5 +83,10 @@ public class HttpApplicationRepository extends AbstractRepository implements App
     @Override
     public Page<Application> search(ApplicationCriteria applicationCriteria, Pageable pageable) throws TechnicalException {
         throw new TechnicalException();
+    }
+
+    @Override
+    public Set<Application> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpAuditRepository.java
@@ -21,8 +21,10 @@ import io.gravitee.repository.management.api.AuditRepository;
 import io.gravitee.repository.management.api.search.AuditCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Audit;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -43,6 +45,11 @@ public class HttpAuditRepository extends AbstractRepository implements AuditRepo
 
     @Override
     public Page<Audit> search(AuditCriteria filter, Pageable pageable) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCommandRepository.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -52,6 +54,11 @@ public class HttpCommandRepository extends AbstractRepository implements Command
 
     @Override
     public void delete(String s) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Command> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCustomUserFieldsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpCustomUserFieldsRepository.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CustomUserFieldsRepository;
 import io.gravitee.repository.management.model.CustomUserField;
 import io.gravitee.repository.management.model.CustomUserFieldReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -51,8 +53,12 @@ public class HttpCustomUserFieldsRepository extends AbstractRepository implement
     }
 
     @Override
-    public List<CustomUserField> findByReferenceIdAndReferenceType(String refId, CustomUserFieldReferenceType refType)
-        throws TechnicalException {
+    public List<CustomUserField> findByReferenceIdAndReferenceType(String refId, CustomUserFieldReferenceType refType) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<CustomUserField> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpEventRepository.java
@@ -23,9 +23,11 @@ import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Event;
 import io.vertx.ext.web.codec.BodyCodec;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -94,5 +96,10 @@ public class HttpEventRepository extends AbstractRepository implements EventRepo
             // Ensure that an exception is thrown and managed by the caller
             throw new IllegalStateException(te);
         }
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpGenericNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpGenericNotificationConfigRepository.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.GenericNotificationConfigRepository;
 import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.repository.management.model.NotificationReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -51,19 +53,22 @@ public class HttpGenericNotificationConfigRepository extends AbstractRepository 
     }
 
     @Override
-    public List<GenericNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<GenericNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<GenericNotificationConfig> findByReference(NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<GenericNotificationConfig> findByReference(NotificationReferenceType referenceType, String referenceId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public void deleteByConfig(String config) throws TechnicalException {
+    public void deleteByConfig(String config) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<GenericNotificationConfig> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMembershipRepository.java
@@ -20,10 +20,11 @@ import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -52,29 +53,27 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         throw new IllegalStateException();
     }
 
-    public void deleteMembers(MembershipReferenceType referenceType, String referenceId) throws TechnicalException {
+    public void deleteMembers(MembershipReferenceType referenceType, String referenceId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Membership> findByIds(Set<String> membershipIds) throws TechnicalException {
+    public Set<Membership> findByIds(Set<String> membershipIds) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Membership> findByReferenceAndRoleId(MembershipReferenceType referenceType, String referenceId, String roleId)
-        throws TechnicalException {
+    public Set<Membership> findByReferenceAndRoleId(MembershipReferenceType referenceType, String referenceId, String roleId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Membership> findByReferencesAndRoleId(MembershipReferenceType referenceType, List<String> referenceIds, String roleId)
-        throws TechnicalException {
+    public Set<Membership> findByReferencesAndRoleId(MembershipReferenceType referenceType, List<String> referenceIds, String roleId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Membership> findByRoleId(String roleId) throws TechnicalException {
+    public Set<Membership> findByRoleId(String roleId) {
         throw new IllegalStateException();
     }
 
@@ -83,7 +82,7 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         String memberId,
         MembershipMemberType memberType,
         MembershipReferenceType referenceType
-    ) throws TechnicalException {
+    ) {
         throw new IllegalStateException();
     }
 
@@ -93,7 +92,7 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String sourceId
-    ) throws TechnicalException {
+    ) {
         throw new IllegalStateException();
     }
 
@@ -103,7 +102,7 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String roleId
-    ) throws TechnicalException {
+    ) {
         throw new IllegalStateException();
     }
 
@@ -114,12 +113,12 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         MembershipReferenceType referenceType,
         String referenceId,
         String roleId
-    ) throws TechnicalException {
+    ) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Membership> findByMemberIdAndMemberType(String memberId, MembershipMemberType memberType) throws TechnicalException {
+    public Set<Membership> findByMemberIdAndMemberType(String memberId, MembershipMemberType memberType) {
         throw new IllegalStateException();
     }
 
@@ -129,7 +128,7 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String referenceId
-    ) throws TechnicalException {
+    ) {
         throw new IllegalStateException();
     }
 
@@ -138,7 +137,12 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         List<String> memberIds,
         MembershipMemberType memberType,
         MembershipReferenceType referenceType
-    ) throws TechnicalException {
+    ) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Membership> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMetadataRepository.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.MetadataRepository;
 import io.gravitee.repository.management.model.Metadata;
 import io.gravitee.repository.management.model.MetadataReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -51,18 +53,22 @@ public class HttpMetadataRepository extends AbstractRepository implements Metada
     }
 
     @Override
-    public List<Metadata> findByKeyAndReferenceType(String key, MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByKeyAndReferenceType(String key, MetadataReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Metadata> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpOrganizationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpOrganizationRepository.java
@@ -19,10 +19,10 @@ import io.gravitee.repository.bridge.client.utils.BodyCodecs;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
-import java.util.Collection;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -52,12 +52,12 @@ public class HttpOrganizationRepository extends AbstractRepository implements Or
     }
 
     @Override
-    public Long count() throws TechnicalException {
+    public Long count() {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Organization> findByHrids(Set<String> hrids) throws TechnicalException {
+    public Set<Organization> findByHrids(Set<String> hrids) {
         try {
             return blockingGet(
                 get("/organizations/_byHrids", BodyCodecs.set(Organization.class)).addQueryParam("hrids", String.join(",", hrids)).send()
@@ -70,7 +70,7 @@ public class HttpOrganizationRepository extends AbstractRepository implements Or
     }
 
     @Override
-    public Collection<Organization> findAll() throws TechnicalException {
+    public Set<Organization> findAll() throws TechnicalException {
         try {
             return blockingGet(get("/organizations", BodyCodecs.set(Organization.class)).send()).payload();
         } catch (TechnicalException te) {

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRepository.java
@@ -21,9 +21,11 @@ import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -58,13 +60,17 @@ public class HttpPageRepository extends AbstractRepository implements PageReposi
     }
 
     @Override
-    public Integer findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, PageReferenceType referenceType)
-        throws TechnicalException {
+    public Integer findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, PageReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
     public io.gravitee.common.data.domain.Page<Page> findAll(Pageable pageable) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Page> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPageRevisionRepository.java
@@ -22,6 +22,8 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.PageRevision;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
 import org.springframework.stereotype.Component;
 
 /**
@@ -36,6 +38,7 @@ public class HttpPageRevisionRepository extends AbstractRepository implements Pa
         throw new IllegalStateException();
     }
 
+    @Override
     public Page<PageRevision> findAll(Pageable pageable) throws TechnicalException {
         throw new IllegalStateException();
     }
@@ -46,12 +49,17 @@ public class HttpPageRevisionRepository extends AbstractRepository implements Pa
     }
 
     @Override
-    public List<PageRevision> findAllByPageId(String pageId) throws TechnicalException {
+    public List<PageRevision> findAllByPageId(String pageId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<PageRevision> findLastByPageId(String pageId) throws TechnicalException {
+    public Optional<PageRevision> findLastByPageId(String pageId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<PageRevision> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpParameterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpParameterRepository.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ParameterRepository;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -51,13 +53,17 @@ public class HttpParameterRepository extends AbstractRepository implements Param
     }
 
     @Override
-    public List<Parameter> findByKeys(List<String> keys, String referenceId, ParameterReferenceType referenceType)
-        throws TechnicalException {
+    public List<Parameter> findByKeys(List<String> keys, String referenceId, ParameterReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
     public List<Parameter> findAll(String referenceId, ParameterReferenceType referenceType) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Parameter> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPlanRepository.java
@@ -19,10 +19,11 @@ import io.gravitee.repository.bridge.client.utils.BodyCodecs;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -59,5 +60,10 @@ public class HttpPlanRepository extends AbstractRepository implements PlanReposi
     @Override
     public Set<Plan> findByApi(String apiId) throws TechnicalException {
         return blockingGet(get("/apis/" + apiId + "/plans", BodyCodecs.set(Plan.class)).send()).payload();
+    }
+
+    @Override
+    public Set<Plan> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationConfigRepository.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.PortalNotificationConfig;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -53,18 +55,22 @@ public class HttpPortalNotificationConfigRepository extends AbstractRepository i
     }
 
     @Override
-    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public void deleteByUser(String user) throws TechnicalException {
+    public void deleteByUser(String user) {
         throw new IllegalStateException();
     }
 
     @Override
-    public void deleteReference(NotificationReferenceType referenceType, String referenceId) throws TechnicalException {
+    public void deleteReference(NotificationReferenceType referenceType, String referenceId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<PortalNotificationConfig> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPortalNotificationRepository.java
@@ -18,9 +18,11 @@ package io.gravitee.repository.bridge.client.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNotificationRepository;
 import io.gravitee.repository.management.model.PortalNotification;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -40,7 +42,7 @@ public class HttpPortalNotificationRepository extends AbstractRepository impleme
     }
 
     @Override
-    public List<PortalNotification> findByUser(String user) throws TechnicalException {
+    public List<PortalNotification> findByUser(String user) {
         throw new IllegalStateException();
     }
 
@@ -50,12 +52,17 @@ public class HttpPortalNotificationRepository extends AbstractRepository impleme
     }
 
     @Override
-    public void deleteAll(String user) throws TechnicalException {
+    public void deleteAll(String user) {
         throw new IllegalStateException();
     }
 
     @Override
     public Optional<PortalNotification> findById(String id) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<PortalNotification> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingAnswerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingAnswerRepository.java
@@ -18,9 +18,11 @@ package io.gravitee.repository.bridge.client.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.RatingAnswerRepository;
 import io.gravitee.repository.management.model.RatingAnswer;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -35,7 +37,7 @@ public class HttpRatingAnswerRepository extends AbstractRepository implements Ra
     }
 
     @Override
-    public List<RatingAnswer> findByRating(String rating) throws TechnicalException {
+    public List<RatingAnswer> findByRating(String rating) {
         throw new IllegalStateException();
     }
 
@@ -51,6 +53,11 @@ public class HttpRatingAnswerRepository extends AbstractRepository implements Ra
 
     @Override
     public void delete(String id) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<RatingAnswer> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpRatingRepository.java
@@ -21,9 +21,11 @@ import io.gravitee.repository.management.api.RatingRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Rating;
 import io.gravitee.repository.management.model.RatingReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -53,19 +55,22 @@ public class HttpRatingRepository extends AbstractRepository implements RatingRe
     }
 
     @Override
-    public Page<Rating> findByReferenceIdAndReferenceTypePageable(String referenceId, RatingReferenceType referenceType, Pageable pageable)
-        throws TechnicalException {
+    public Page<Rating> findByReferenceIdAndReferenceTypePageable(String referenceId, RatingReferenceType referenceType, Pageable pageable) {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<Rating> findByReferenceIdAndReferenceType(String referenceId, RatingReferenceType referenceType) throws TechnicalException {
+    public List<Rating> findByReferenceIdAndReferenceType(String referenceId, RatingReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<Rating> findByReferenceIdAndReferenceTypeAndUser(String referenceId, RatingReferenceType referenceType, String user)
-        throws TechnicalException {
+    public Optional<Rating> findByReferenceIdAndReferenceTypeAndUser(String referenceId, RatingReferenceType referenceType, String user) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Rating> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpSubscriptionRepository.java
@@ -22,9 +22,11 @@ import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -67,5 +69,10 @@ public class HttpSubscriptionRepository extends AbstractRepository implements Su
     @Override
     public List<Subscription> search(SubscriptionCriteria criteria) throws TechnicalException {
         return blockingGet(post("/subscriptions/_search", BodyCodecs.list(Subscription.class)).send(criteria)).payload();
+    }
+
+    @Override
+    public Set<Subscription> findAll() throws TechnicalException {
+        throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpTagRepository.java
@@ -19,9 +19,10 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TagRepository;
 import io.gravitee.repository.management.model.Tag;
 import io.gravitee.repository.management.model.TagReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -51,12 +52,17 @@ public class HttpTagRepository extends AbstractRepository implements TagReposito
     }
 
     @Override
-    public Optional<Tag> findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType) throws TechnicalException {
+    public Optional<Tag> findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Tag> findByReference(String referenceId, TagReferenceType referenceType) throws TechnicalException {
+    public Set<Tag> findByReference(String referenceId, TagReferenceType referenceType) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Tag> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpTenantRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpTenantRepository.java
@@ -19,9 +19,10 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TenantRepository;
 import io.gravitee.repository.management.model.Tenant;
 import io.gravitee.repository.management.model.TenantReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -51,13 +52,17 @@ public class HttpTenantRepository extends AbstractRepository implements TenantRe
     }
 
     @Override
-    public Set<Tenant> findByReference(String referenceId, TenantReferenceType referenceType) throws TechnicalException {
+    public Set<Tenant> findByReference(String referenceId, TenantReferenceType referenceType) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<Tenant> findByIdAndReference(String tenantId, String referenceId, TenantReferenceType referenceType)
-        throws TechnicalException {
+    public Optional<Tenant> findByIdAndReference(String tenantId, String referenceId, TenantReferenceType referenceType) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Tenant> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpUserRepository.java
@@ -21,10 +21,11 @@ import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.management.model.User;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -54,7 +55,7 @@ public class HttpUserRepository extends AbstractRepository implements UserReposi
     }
 
     @Override
-    public Set<User> findByIds(List<String> ids) throws TechnicalException {
+    public Set<User> findByIds(List<String> ids) {
         throw new IllegalStateException();
     }
 
@@ -64,12 +65,17 @@ public class HttpUserRepository extends AbstractRepository implements UserReposi
     }
 
     @Override
-    public Optional<User> findBySource(String source, String sourceId, String organizationId) throws TechnicalException {
+    public Optional<User> findBySource(String source, String sourceId, String organizationId) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<User> findByEmail(String email, String organizationId) throws TechnicalException {
+    public Optional<User> findByEmail(String email, String organizationId) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<User> findAll() throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.jdbc.common;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.gravitee.repository.jdbc.datasource.NoOpDataSource;
 import io.gravitee.repository.jdbc.exception.DatabaseInitializationException;
 import java.sql.Connection;
 import java.util.Map;
@@ -155,6 +156,10 @@ public abstract class AbstractJdbcRepositoryConfiguration implements Application
         Boolean liquibase = readPropertyValue("jdbc.liquibase", Boolean.class, LIQUIBASE_ENABLED);
         if (liquibase) {
             runLiquibase(dataSource);
+        }
+
+        if (readPropertyValue("jdbc.sqlOnly", Boolean.class, false)) {
+            return new NoOpDataSource(dataSource);
         }
 
         return dataSource;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/LoggablePreparedStatement.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/LoggablePreparedStatement.java
@@ -1,0 +1,626 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.datasource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
+import java.util.Calendar;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LoggablePreparedStatement implements PreparedStatement {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggablePreparedStatement.class);
+
+    private final PreparedStatement preparedStatement;
+
+    public LoggablePreparedStatement(PreparedStatement preparedStatement) {
+        this.preparedStatement = preparedStatement;
+    }
+
+    @Override
+    public ResultSet executeQuery() throws SQLException {
+        return preparedStatement.executeQuery();
+    }
+
+    @Override
+    public int executeUpdate() throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1 ; // preparedStatement.executeUpdate();
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
+        preparedStatement.setNull(parameterIndex, sqlType);
+    }
+
+    @Override
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+        preparedStatement.setBoolean(parameterIndex, x);
+    }
+
+    @Override
+    public void setByte(int parameterIndex, byte x) throws SQLException {
+        preparedStatement.setByte(parameterIndex, x);
+    }
+
+    @Override
+    public void setShort(int parameterIndex, short x) throws SQLException {
+        preparedStatement.setShort(parameterIndex, x);
+    }
+
+    @Override
+    public void setInt(int parameterIndex, int x) throws SQLException {
+        preparedStatement.setInt(parameterIndex, x);
+    }
+
+    @Override
+    public void setLong(int parameterIndex, long x) throws SQLException {
+        preparedStatement.setLong(parameterIndex, x);
+    }
+
+    @Override
+    public void setFloat(int parameterIndex, float x) throws SQLException {
+        preparedStatement.setFloat(parameterIndex, x);
+    }
+
+    @Override
+    public void setDouble(int parameterIndex, double x) throws SQLException {
+        preparedStatement.setDouble(parameterIndex, x);
+    }
+
+    @Override
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+        preparedStatement.setBigDecimal(parameterIndex, x);
+    }
+
+    @Override
+    public void setString(int parameterIndex, String x) throws SQLException {
+        preparedStatement.setString(parameterIndex, x);
+    }
+
+    @Override
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+        preparedStatement.setBytes(parameterIndex, x);
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x) throws SQLException {
+        preparedStatement.setDate(parameterIndex, x);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x) throws SQLException {
+        preparedStatement.setTime(parameterIndex, x);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+        preparedStatement.setTimestamp(parameterIndex, x);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        preparedStatement.setAsciiStream(parameterIndex, x, length);
+    }
+
+    @Override
+    @Deprecated(since = "1.2")
+    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        preparedStatement.setUnicodeStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        preparedStatement.setBinaryStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void clearParameters() throws SQLException {
+        preparedStatement.clearParameters();
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x);
+    }
+
+    @Override
+    public boolean execute() throws SQLException {
+        return preparedStatement.execute();
+    }
+
+    @Override
+    public void addBatch() throws SQLException {
+        preparedStatement.addBatch();
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader, int length) throws SQLException {
+        preparedStatement.setCharacterStream(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setRef(int parameterIndex, Ref x) throws SQLException {
+        preparedStatement.setRef(parameterIndex, x);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, Blob x) throws SQLException {
+        preparedStatement.setBlob(parameterIndex, x);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Clob x) throws SQLException {
+        preparedStatement.setClob(parameterIndex, x);
+    }
+
+    @Override
+    public void setArray(int parameterIndex, Array x) throws SQLException {
+        preparedStatement.setArray(parameterIndex, x);
+    }
+
+    @Override
+    public ResultSetMetaData getMetaData() throws SQLException {
+        return preparedStatement.getMetaData();
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+        preparedStatement.setDate(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+        preparedStatement.setTime(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+        preparedStatement.setTimestamp(parameterIndex, x, cal);
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+        preparedStatement.setNull(parameterIndex, sqlType, typeName);
+    }
+
+    @Override
+    public void setURL(int parameterIndex, URL x) throws SQLException {
+        preparedStatement.setURL(parameterIndex, x);
+    }
+
+    @Override
+    public ParameterMetaData getParameterMetaData() throws SQLException {
+        return preparedStatement.getParameterMetaData();
+    }
+
+    @Override
+    public void setRowId(int parameterIndex, RowId x) throws SQLException {
+        preparedStatement.setRowId(parameterIndex, x);
+    }
+
+    @Override
+    public void setNString(int parameterIndex, String value) throws SQLException {
+        preparedStatement.setNString(parameterIndex, value);
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader value, long length) throws SQLException {
+        preparedStatement.setNCharacterStream(parameterIndex, value, length);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, NClob value) throws SQLException {
+        preparedStatement.setNClob(parameterIndex, value);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        preparedStatement.setClob(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream inputStream, long length) throws SQLException {
+        preparedStatement.setBlob(parameterIndex, inputStream, length);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader reader, long length) throws SQLException {
+        preparedStatement.setNClob(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setSQLXML(int parameterIndex, SQLXML xmlObject) throws SQLException {
+        preparedStatement.setSQLXML(parameterIndex, xmlObject);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        preparedStatement.setAsciiStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        preparedStatement.setBinaryStream(parameterIndex, x, length);
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader, long length) throws SQLException {
+        preparedStatement.setCharacterStream(parameterIndex, reader, length);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+        preparedStatement.setAsciiStream(parameterIndex, x);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+        preparedStatement.setBinaryStream(parameterIndex, x);
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
+        preparedStatement.setCharacterStream(parameterIndex, reader);
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader value) throws SQLException {
+        preparedStatement.setNCharacterStream(parameterIndex, value);
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader reader) throws SQLException {
+        preparedStatement.setClob(parameterIndex, reader);
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+        preparedStatement.setBlob(parameterIndex, inputStream);
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader reader) throws SQLException {
+        preparedStatement.setNClob(parameterIndex, reader);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType, scaleOrLength);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+        preparedStatement.setObject(parameterIndex, x, targetSqlType);
+    }
+
+    @Override
+    public long executeLargeUpdate() throws SQLException {
+        return preparedStatement.executeLargeUpdate();
+    }
+
+    @Override
+    public ResultSet executeQuery(String sql) throws SQLException {
+        return preparedStatement.executeQuery(sql);
+    }
+
+    @Override
+    public int executeUpdate(String sql) throws SQLException {
+        return preparedStatement.executeUpdate(sql);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        preparedStatement.close();
+    }
+
+    @Override
+    public int getMaxFieldSize() throws SQLException {
+        return preparedStatement.getMaxFieldSize();
+    }
+
+    @Override
+    public void setMaxFieldSize(int max) throws SQLException {
+        preparedStatement.setMaxFieldSize(max);
+    }
+
+    @Override
+    public int getMaxRows() throws SQLException {
+        return preparedStatement.getMaxRows();
+    }
+
+    @Override
+    public void setMaxRows(int max) throws SQLException {
+        preparedStatement.setMaxRows(max);
+    }
+
+    @Override
+    public void setEscapeProcessing(boolean enable) throws SQLException {
+        preparedStatement.setEscapeProcessing(enable);
+    }
+
+    @Override
+    public int getQueryTimeout() throws SQLException {
+        return preparedStatement.getQueryTimeout();
+    }
+
+    @Override
+    public void setQueryTimeout(int seconds) throws SQLException {
+        preparedStatement.setQueryTimeout(seconds);
+    }
+
+    @Override
+    public void cancel() throws SQLException {
+        preparedStatement.cancel();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return preparedStatement.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        preparedStatement.clearWarnings();
+    }
+
+    @Override
+    public void setCursorName(String name) throws SQLException {
+        preparedStatement.setCursorName(name);
+    }
+
+    @Override
+    public boolean execute(String sql) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public ResultSet getResultSet() throws SQLException {
+        return preparedStatement.getResultSet();
+    }
+
+    @Override
+    public int getUpdateCount() throws SQLException {
+        return preparedStatement.getUpdateCount();
+    }
+
+    @Override
+    public boolean getMoreResults() throws SQLException {
+        return preparedStatement.getMoreResults();
+    }
+
+    @Override
+    public void setFetchDirection(int direction) throws SQLException {
+        preparedStatement.setFetchDirection(direction);
+    }
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        return preparedStatement.getFetchDirection();
+    }
+
+    @Override
+    public void setFetchSize(int rows) throws SQLException {
+        preparedStatement.setFetchSize(rows);
+    }
+
+    @Override
+    public int getFetchSize() throws SQLException {
+        return preparedStatement.getFetchSize();
+    }
+
+    @Override
+    public int getResultSetConcurrency() throws SQLException {
+        return preparedStatement.getResultSetConcurrency();
+    }
+
+    @Override
+    public int getResultSetType() throws SQLException {
+        return preparedStatement.getResultSetType();
+    }
+
+    @Override
+    public void addBatch(String sql) throws SQLException {
+        preparedStatement.addBatch(sql);
+    }
+
+    @Override
+    public void clearBatch() throws SQLException {
+        preparedStatement.clearBatch();
+    }
+
+    @Override
+    public int[] executeBatch() throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return new int[]{-1};
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return preparedStatement.getConnection();
+    }
+
+    @Override
+    public boolean getMoreResults(int current) throws SQLException {
+        return preparedStatement.getMoreResults(current);
+    }
+
+    @Override
+    public ResultSet getGeneratedKeys() throws SQLException {
+        return preparedStatement.getGeneratedKeys();
+    }
+
+    @Override
+    public int executeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1;
+    }
+
+    @Override
+    public int executeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1;
+    }
+
+    @Override
+    public int executeUpdate(String sql, String[] columnNames) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1;
+    }
+
+    @Override
+    public boolean execute(String sql, int autoGeneratedKeys) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public boolean execute(String sql, int[] columnIndexes) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public boolean execute(String sql, String[] columnNames) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return false;
+    }
+
+    @Override
+    public int getResultSetHoldability() throws SQLException {
+        return preparedStatement.getResultSetHoldability();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return preparedStatement.isClosed();
+    }
+
+    @Override
+    public void setPoolable(boolean poolable) throws SQLException {
+        preparedStatement.setPoolable(poolable);
+    }
+
+    @Override
+    public boolean isPoolable() throws SQLException {
+        return preparedStatement.isPoolable();
+    }
+
+    @Override
+    public void closeOnCompletion() throws SQLException {
+        preparedStatement.closeOnCompletion();
+    }
+
+    @Override
+    public boolean isCloseOnCompletion() throws SQLException {
+        return preparedStatement.isCloseOnCompletion();
+    }
+
+    @Override
+    public long getLargeUpdateCount() throws SQLException {
+        return preparedStatement.getLargeUpdateCount();
+    }
+
+    @Override
+    public void setLargeMaxRows(long max) throws SQLException {
+        preparedStatement.setLargeMaxRows(max);
+    }
+
+    @Override
+    public long getLargeMaxRows() throws SQLException {
+        return preparedStatement.getLargeMaxRows();
+    }
+
+    @Override
+    public long[] executeLargeBatch() throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return new long[]{ -1L };
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, int autoGeneratedKeys) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, int[] columnIndexes) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public long executeLargeUpdate(String sql, String[] columnNames) throws SQLException {
+        LOGGER.warn("{}", preparedStatement);
+        return -1L;
+    }
+
+    @Override
+    public String enquoteLiteral(String val) throws SQLException {
+        return preparedStatement.enquoteLiteral(val);
+    }
+
+    @Override
+    public String enquoteIdentifier(String identifier, boolean alwaysQuote) throws SQLException {
+        return preparedStatement.enquoteIdentifier(identifier, alwaysQuote);
+    }
+
+    @Override
+    public boolean isSimpleIdentifier(String identifier) throws SQLException {
+        return preparedStatement.isSimpleIdentifier(identifier);
+    }
+
+    @Override
+    public String enquoteNCharLiteral(String val) throws SQLException {
+        return preparedStatement.enquoteNCharLiteral(val);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return preparedStatement.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return preparedStatement.isWrapperFor(iface);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpConnection.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpConnection.java
@@ -1,0 +1,334 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.datasource;
+
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpConnection implements Connection {
+
+    private final Connection connection;
+
+    public NoOpConnection(Connection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public Statement createStatement() throws SQLException {
+        return connection.createStatement();
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+        return new LoggablePreparedStatement(connection.prepareStatement(sql));
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        return connection.prepareCall(sql);
+    }
+
+    @Override
+    public String nativeSQL(String sql) throws SQLException {
+        return connection.nativeSQL(sql);
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        connection.setAutoCommit(autoCommit);
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        return connection.getAutoCommit();
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        // Do nothing
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        // Do nothing
+    }
+
+    @Override
+    public void close() throws SQLException {
+        connection.close();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return connection.isClosed();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return connection.getMetaData();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        connection.setReadOnly(readOnly);
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        return connection.isReadOnly();
+    }
+
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+        connection.setCatalog(catalog);
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+        return connection.getCatalog();
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+        connection.setTransactionIsolation(level);
+    }
+
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+        return connection.getTransactionIsolation();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return connection.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        connection.clearWarnings();
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+        return connection.createStatement(resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return connection.prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return connection.prepareCall(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        return connection.getTypeMap();
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        connection.setTypeMap(map);
+    }
+
+    @Override
+    public void setHoldability(int holdability) throws SQLException {
+        connection.setHoldability(holdability);
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        return connection.getHoldability();
+    }
+
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+        return connection.setSavepoint();
+    }
+
+    @Override
+    public Savepoint setSavepoint(String name) throws SQLException {
+        return connection.setSavepoint(name);
+    }
+
+    @Override
+    public void rollback(Savepoint savepoint) throws SQLException {
+        connection.rollback(savepoint);
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        connection.releaseSavepoint(savepoint);
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return connection.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return connection.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return connection.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+        return connection.prepareStatement(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        return connection.prepareStatement(sql, columnIndexes);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+        return connection.prepareStatement(sql, columnNames);
+    }
+
+    @Override
+    public Clob createClob() throws SQLException {
+        return connection.createClob();
+    }
+
+    @Override
+    public Blob createBlob() throws SQLException {
+        return connection.createBlob();
+    }
+
+    @Override
+    public NClob createNClob() throws SQLException {
+        return connection.createNClob();
+    }
+
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+        return connection.createSQLXML();
+    }
+
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        return connection.isValid(timeout);
+    }
+
+    @Override
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+        connection.setClientInfo(name, value);
+    }
+
+    @Override
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+        connection.setClientInfo(properties);
+    }
+
+    @Override
+    public String getClientInfo(String name) throws SQLException {
+        return connection.getClientInfo(name);
+    }
+
+    @Override
+    public Properties getClientInfo() throws SQLException {
+        return connection.getClientInfo();
+    }
+
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        return connection.createArrayOf(typeName, elements);
+    }
+
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        return connection.createStruct(typeName, attributes);
+    }
+
+    @Override
+    public void setSchema(String schema) throws SQLException {
+        connection.setSchema(schema);
+    }
+
+    @Override
+    public String getSchema() throws SQLException {
+        return connection.getSchema();
+    }
+
+    @Override
+    public void abort(Executor executor) throws SQLException {
+        connection.abort(executor);
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        connection.setNetworkTimeout(executor, milliseconds);
+    }
+
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+        return connection.getNetworkTimeout();
+    }
+
+    @Override
+    public void beginRequest() throws SQLException {
+        connection.beginRequest();
+    }
+
+    @Override
+    public void endRequest() throws SQLException {
+        connection.endRequest();
+    }
+
+    @Override
+    public boolean setShardingKeyIfValid(ShardingKey shardingKey, ShardingKey superShardingKey, int timeout) throws SQLException {
+        return connection.setShardingKeyIfValid(shardingKey, superShardingKey, timeout);
+    }
+
+    @Override
+    public boolean setShardingKeyIfValid(ShardingKey shardingKey, int timeout) throws SQLException {
+        return connection.setShardingKeyIfValid(shardingKey, timeout);
+    }
+
+    @Override
+    public void setShardingKey(ShardingKey shardingKey, ShardingKey superShardingKey) throws SQLException {
+        connection.setShardingKey(shardingKey, superShardingKey);
+    }
+
+    @Override
+    public void setShardingKey(ShardingKey shardingKey) throws SQLException {
+        connection.setShardingKey(shardingKey);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return connection.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return connection.isWrapperFor(iface);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpDataSource.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/datasource/NoOpDataSource.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.datasource;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.*;
+import java.util.logging.Logger;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpDataSource implements DataSource {
+
+    private final DataSource dataSource;
+
+    public NoOpDataSource(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return new NoOpConnection(dataSource.getConnection());
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return new NoOpConnection(dataSource.getConnection(username, password));
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return dataSource.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        dataSource.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        dataSource.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return dataSource.getLoginTimeout();
+    }
+
+    @Override
+    public ConnectionBuilder createConnectionBuilder() throws SQLException {
+        return dataSource.createConnectionBuilder();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return dataSource.getParentLogger();
+    }
+
+    @Override
+    public ShardingKeyBuilder createShardingKeyBuilder() throws SQLException {
+        return dataSource.createShardingKeyBuilder();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return dataSource.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return dataSource.isWrapperFor(iface);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractFindAllRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractFindAllRepository.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author GraviteeSource Team
+ */
+public abstract class JdbcAbstractFindAllRepository<T> extends JdbcAbstractRepository<T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JdbcAbstractFindAllRepository.class);
+
+    JdbcAbstractFindAllRepository(String prefix, String tableName) {
+        super(prefix, tableName);
+    }
+
+    public Set<T> findAll() throws TechnicalException {
+        LOGGER.debug("JdbcAbstractFindAllRepository<{}>.findAll()", getOrm().getTableName());
+        try {
+            return new HashSet<>(jdbcTemplate.query(getOrm().getSelectAllSql(), getRowMapper()));
+        } catch (final Exception ex) {
+            String errorMessage = String.format("Failed to find all %s items:", getOrm().getTableName());
+            LOGGER.error(errorMessage, ex);
+            throw new TechnicalException(errorMessage, ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiQualityRuleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiQualityRuleRepository.java
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Repository;
  * @author GraviteeSource Team
  */
 @Repository
-public class JdbcApiQualityRuleRepository extends JdbcAbstractRepository<ApiQualityRule> implements ApiQualityRuleRepository {
+public class JdbcApiQualityRuleRepository extends JdbcAbstractFindAllRepository<ApiQualityRule> implements ApiQualityRuleRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcApiQualityRuleRepository.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -15,11 +15,6 @@
  */
 package io.gravitee.repository.jdbc.management;
 
-import static java.lang.String.format;
-import static org.springframework.util.CollectionUtils.isEmpty;
-import static org.springframework.util.StringUtils.hasText;
-import static org.springframework.util.StringUtils.isEmpty;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
@@ -30,17 +25,25 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
 import io.gravitee.repository.management.api.search.Pageable;
-import io.gravitee.repository.management.model.*;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.Types;
-import java.util.*;
-import java.util.stream.Collectors;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiLifecycleState;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.repository.management.model.Visibility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.springframework.util.StringUtils.hasText;
 
 /**
  * @author njt
@@ -374,5 +377,17 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
             addGroups(api);
         }
         return apis;
+    }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        LOGGER.debug("JdbcApiRepository.findAll()");
+        try {
+            return new HashSet<>(jdbcTemplate.query(getOrm().getSelectAllSql(), getRowMapper()));
+        } catch (final Exception ex) {
+            final String error = "Failed to find all api";
+            LOGGER.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
@@ -285,4 +285,9 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
         }
         return started;
     }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCustomUserFieldsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcCustomUserFieldsRepository.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Repository;
  * @author GraviteeSource Team
  */
 @Repository
-public class JdbcCustomUserFieldsRepository extends JdbcAbstractRepository<CustomUserField> implements CustomUserFieldsRepository {
+public class JdbcCustomUserFieldsRepository extends JdbcAbstractFindAllRepository<CustomUserField> implements CustomUserFieldsRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcCustomUserFieldsRepository.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
@@ -28,6 +28,7 @@ import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.sql.*;
@@ -401,5 +402,10 @@ public class JdbcEventRepository extends JdbcAbstractPageableRepository<Event> i
             filter.getTypes() +
             " }"
         );
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMetadataRepository.java
@@ -38,7 +38,7 @@ import org.springframework.stereotype.Repository;
  * @author njt
  */
 @Repository
-public class JdbcMetadataRepository extends JdbcAbstractRepository<Metadata> implements MetadataRepository {
+public class JdbcMetadataRepository extends JdbcAbstractFindAllRepository<Metadata> implements MetadataRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcMetadataRepository.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRevisionRepository.java
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Repository;
  * @author GraviteeSource Team
  */
 @Repository
-public class JdbcPageRevisionRepository extends JdbcAbstractRepository<PageRevision> implements PageRevisionRepository {
+public class JdbcPageRevisionRepository extends JdbcAbstractFindAllRepository<PageRevision> implements PageRevisionRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcPageRevisionRepository.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcParameterRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcParameterRepository.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Repository;
  *
  */
 @Repository
-public class JdbcParameterRepository extends JdbcAbstractRepository<Parameter> implements ParameterRepository {
+public class JdbcParameterRepository extends JdbcAbstractFindAllRepository<Parameter> implements ParameterRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcParameterRepository.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Repository;
  * @author njt
  */
 @Repository
-public class JdbcPlanRepository extends JdbcAbstractRepository<Plan> implements PlanRepository {
+public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> implements PlanRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcPlanRepository.class);
     private final String PLAN_TAGS;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalNotificationConfigRepository.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public class JdbcPortalNotificationConfigRepository
-    extends JdbcAbstractRepository<PortalNotificationConfig>
+    extends JdbcAbstractFindAllRepository<PortalNotificationConfig>
     implements PortalNotificationConfigRepository {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcPortalNotificationConfigRepository.class);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAlertEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAlertEventRepository.java
@@ -23,9 +23,13 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.AlertEvent;
 import io.gravitee.repository.mongodb.management.internal.api.AlertEventMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.AlertEventMongo;
+import io.gravitee.repository.mongodb.management.internal.model.AlertTriggerMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -122,5 +126,12 @@ public class MongoAlertEventRepository implements AlertEventRepository {
             (int) alertEventsMongo.getPageElements(),
             alertEventsMongo.getTotalElements()
         );
+    }
+
+    @Override
+    public Set<AlertEvent> findAll() throws TechnicalException {
+        return internalAlertEventRepo.findAll().stream()
+            .map(alertEventMongo -> mapper.map(alertEventMongo, AlertEvent.class))
+            .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.repository.mongodb.management;
 
-import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.model.AlertEvent;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.mongodb.management.internal.key.ApiKeyMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ApiKeyMongo;
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -38,8 +36,6 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class MongoApiKeyRepository implements ApiKeyRepository {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(MongoApiKeyRepository.class);
 
     @Autowired
     private GraviteeMapper mapper;
@@ -72,7 +68,7 @@ public class MongoApiKeyRepository implements ApiKeyRepository {
     }
 
     @Override
-    public Set<ApiKey> findBySubscription(String subscription) throws TechnicalException {
+    public Set<ApiKey> findBySubscription(String subscription) {
         return internalApiKeyRepo
             .findBySubscription(subscription)
             .stream()
@@ -96,12 +92,19 @@ public class MongoApiKeyRepository implements ApiKeyRepository {
     }
 
     @Override
-    public List<ApiKey> findByKey(String key) throws TechnicalException {
+    public List<ApiKey> findByKey(String key) {
         return internalApiKeyRepo.findByKey(key).stream().map(apiKey -> mapper.map(apiKey, ApiKey.class)).collect(Collectors.toList());
     }
 
     @Override
-    public Optional<ApiKey> findByKeyAndApi(String key, String api) throws TechnicalException {
+    public Optional<ApiKey> findByKeyAndApi(String key, String api) {
         return internalApiKeyRepo.findByKeyAndApi(key, api).stream().findFirst().map(apiKey -> mapper.map(apiKey, ApiKey.class));
+    }
+
+    @Override
+    public Set<ApiKey> findAll() throws TechnicalException {
+        return internalApiKeyRepo.findAll().stream()
+                .map(apiKeyMongo -> mapper.map(apiKeyMongo, ApiKey.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiQualityRuleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiQualityRuleRepository.java
@@ -15,27 +15,26 @@
  */
 package io.gravitee.repository.mongodb.management;
 
-import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
-
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
-import io.gravitee.repository.management.api.QualityRuleRepository;
-import io.gravitee.repository.management.model.Api;
-import io.gravitee.repository.management.model.ApiQualityRule;
+import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.management.model.ApiQualityRule;
 import io.gravitee.repository.mongodb.management.internal.model.ApiQualityRuleMongo;
 import io.gravitee.repository.mongodb.management.internal.model.ApiQualityRulePkMongo;
-import io.gravitee.repository.mongodb.management.internal.model.QualityRuleMongo;
 import io.gravitee.repository.mongodb.management.internal.quality.ApiQualityRuleMongoRepository;
-import io.gravitee.repository.mongodb.management.internal.quality.QualityRuleMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -125,13 +124,13 @@ public class MongoApiQualityRuleRepository implements ApiQualityRuleRepository {
     }
 
     @Override
-    public List<ApiQualityRule> findByApi(String api) throws TechnicalException {
+    public List<ApiQualityRule> findByApi(String api) {
         final List<ApiQualityRuleMongo> apiQualityRules = internalApiQualityRuleRepo.findByIdApi(api);
         return apiQualityRules.stream().map(apiQualityRuleMongo -> mapper.map(apiQualityRuleMongo, ApiQualityRule.class)).collect(toList());
     }
 
     @Override
-    public List<ApiQualityRule> findByQualityRule(String qualityRule) throws TechnicalException {
+    public List<ApiQualityRule> findByQualityRule(String qualityRule) {
         final List<ApiQualityRuleMongo> apiQualityRules = internalApiQualityRuleRepo.findByIdQualityRule(qualityRule);
         return apiQualityRules.stream().map(apiQualityRuleMongo -> mapper.map(apiQualityRuleMongo, ApiQualityRule.class)).collect(toList());
     }
@@ -156,5 +155,12 @@ public class MongoApiQualityRuleRepository implements ApiQualityRuleRepository {
             LOGGER.error(error, e);
             throw new TechnicalException(error);
         }
+    }
+
+    @Override
+    public Set<ApiQualityRule> findAll() throws TechnicalException {
+        return internalApiQualityRuleRepo.findAll().stream()
+                .map(apiQualityRuleMongo -> mapper.map(apiQualityRuleMongo, ApiQualityRule.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -25,10 +25,13 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.mongodb.management.internal.api.ApiMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -106,5 +109,12 @@ public class MongoApiRepository implements ApiRepository {
 
     private Api mapApi(ApiMongo apiMongo) {
         return (apiMongo == null) ? null : mapper.map(apiMongo, Api.class);
+    }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        return internalApiRepo.findAll().stream()
+                .map(this::mapApi)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
@@ -25,10 +25,11 @@ import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.mongodb.management.internal.application.ApplicationMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.*;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -97,12 +98,12 @@ public class MongoApplicationRepository implements ApplicationRepository {
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids) throws TechnicalException {
+    public Set<Application> findByIds(List<String> ids) {
         return mapApplications(internalApplicationRepo.findByIds(ids));
     }
 
     @Override
-    public Set<Application> findByGroups(List<String> groupIds, ApplicationStatus... statuses) throws TechnicalException {
+    public Set<Application> findByGroups(List<String> groupIds, ApplicationStatus... statuses) {
         if (statuses != null && statuses.length > 0) {
             return mapApplications(internalApplicationRepo.findByGroups(groupIds, Arrays.asList(statuses)));
         } else {
@@ -111,7 +112,7 @@ public class MongoApplicationRepository implements ApplicationRepository {
     }
 
     @Override
-    public Set<Application> findByNameAndStatuses(String partialName, ApplicationStatus... statuses) throws TechnicalException {
+    public Set<Application> findByNameAndStatuses(String partialName, ApplicationStatus... statuses) {
         if (statuses != null && statuses.length > 0) {
             return mapApplications(internalApplicationRepo.findByNameAndStatuses(partialName, Arrays.asList(statuses)));
         } else {
@@ -149,11 +150,18 @@ public class MongoApplicationRepository implements ApplicationRepository {
     }
 
     @Override
-    public Set<Application> findAllByEnvironment(String environmentId, ApplicationStatus... statuses) throws TechnicalException {
+    public Set<Application> findAllByEnvironment(String environmentId, ApplicationStatus... statuses) {
         if (statuses != null && statuses.length > 0) {
             return mapApplications(internalApplicationRepo.findAllByEnvironmentId(environmentId, Arrays.asList(statuses)));
         } else {
             return mapApplications(internalApplicationRepo.findAllByEnvironmentId(environmentId));
         }
+    }
+
+    @Override
+    public Set<Application> findAll() throws TechnicalException {
+        return internalApplicationRepo.findAll().stream()
+                .map(this::mapApplication)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAuditRepository.java
@@ -24,12 +24,14 @@ import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.mongodb.management.internal.audit.AuditMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.AuditMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -73,8 +75,13 @@ public class MongoAuditRepository implements AuditRepository {
 
         Audit res = mapper.map(createdAuditMongo, Audit.class);
 
-        LOGGER.debug("Create audit [{}] - Done", audit.toString());
+        LOGGER.debug("Create audit [{}] - Done", audit);
 
         return res;
+    }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCommandRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCommandRepository.java
@@ -22,12 +22,15 @@ import io.gravitee.repository.management.model.Command;
 import io.gravitee.repository.mongodb.management.internal.message.CommandMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.CommandMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -103,5 +106,12 @@ public class MongoCommandRepository implements CommandRepository {
         logger.debug("Search Command [{}]", criteria);
         List<CommandMongo> result = internalMessageRepo.search(criteria);
         return mapper.collection2list(result, CommandMongo.class, Command.class);
+    }
+
+    @Override
+    public Set<Command> findAll() throws TechnicalException {
+        return internalMessageRepo.findAll().stream()
+                .map(commandMongo -> mapper.map(commandMongo, Command.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCustomUserFieldsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoCustomUserFieldsRepository.java
@@ -23,13 +23,15 @@ import io.gravitee.repository.mongodb.management.internal.model.CustomUserFieldM
 import io.gravitee.repository.mongodb.management.internal.model.CustomUserFieldPkMongo;
 import io.gravitee.repository.mongodb.management.internal.user.CustomUserFieldsMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -70,7 +72,7 @@ public class MongoCustomUserFieldsRepository implements CustomUserFieldsReposito
             field.getReferenceType().name()
         );
         final Optional<CustomUserFieldMongo> previousField = internalMongoRepo.findById(id);
-        if (!previousField.isPresent()) {
+        if (previousField.isEmpty()) {
             throw new IllegalStateException(String.format("No CustomUserField found with id [%s]", id));
         }
 
@@ -109,5 +111,12 @@ public class MongoCustomUserFieldsRepository implements CustomUserFieldsReposito
 
         logger.debug("Find CustomUserField by Reference [{}/{}] - Done", refId, referenceType);
         return fields.stream().map(f -> mapper.map(f, CustomUserField.class)).collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<CustomUserField> findAll() throws TechnicalException {
+        return internalMongoRepo.findAll().stream()
+                .map(customUserFieldMongo -> mapper.map(customUserFieldMongo, CustomUserField.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEntrypointRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEntrypointRepository.java
@@ -22,14 +22,15 @@ import io.gravitee.repository.management.model.EntrypointReferenceType;
 import io.gravitee.repository.mongodb.management.internal.api.EntrypointMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.EntrypointMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -57,8 +58,7 @@ public class MongoEntrypointRepository implements EntrypointRepository {
     }
 
     @Override
-    public Optional<Entrypoint> findByIdAndReference(String entrypointId, String referenceId, EntrypointReferenceType referenceType)
-        throws TechnicalException {
+    public Optional<Entrypoint> findByIdAndReference(String entrypointId, String referenceId, EntrypointReferenceType referenceType) {
         LOGGER.debug("Find entry point by ID and reference [{}, {}, {}]", entrypointId, referenceId, referenceType);
 
         final EntrypointMongo entrypoint = internalEntryPointRepo
@@ -137,5 +137,12 @@ public class MongoEntrypointRepository implements EntrypointRepository {
                 }
             )
             .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Entrypoint> findAll() throws TechnicalException {
+        return internalEntryPointRepo.findAll().stream()
+                .map(entrypointMongo -> mapper.map(entrypointMongo, Entrypoint.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoEventRepository.java
@@ -25,12 +25,14 @@ import io.gravitee.repository.management.model.EventType;
 import io.gravitee.repository.mongodb.management.internal.event.EventMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.EventMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -39,7 +41,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MongoEventRepository implements EventRepository {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private EventMongoRepository internalEventRepo;
@@ -164,5 +166,10 @@ public class MongoEventRepository implements EventRepository {
         event.setUpdatedAt(eventMongo.getUpdatedAt());
 
         return event;
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        throw new IllegalStateException("not implemented cause of high amount of data. Use pageable search instead");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoFlowRepository.java
@@ -22,13 +22,15 @@ import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.repository.mongodb.management.internal.flow.FlowMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.FlowMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -37,7 +39,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MongoFlowRepository implements FlowRepository {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private FlowMongoRepository internalRepository;
@@ -70,13 +72,12 @@ public class MongoFlowRepository implements FlowRepository {
             throw new IllegalStateException("Group must not be null");
         }
 
-        final FlowMongo flowMongo = internalRepository
+        internalRepository
             .findById(flow.getId())
             .orElseThrow(() -> new IllegalStateException(String.format("No flow found with id [%s]", flow.getId())));
 
         logger.debug("Update flow [{}]", flow.getName());
-        Flow updatedFlow = map(internalRepository.save(map(flow)));
-        return updatedFlow;
+        return map(internalRepository.save(map(flow)));
     }
 
     @Override
@@ -103,5 +104,12 @@ public class MongoFlowRepository implements FlowRepository {
 
     private Flow map(FlowMongo flow) {
         return mapper.map(flow, Flow.class);
+    }
+
+    @Override
+    public Set<Flow> findAll() throws TechnicalException {
+        return internalRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGenericNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGenericNotificationConfigRepository.java
@@ -21,13 +21,15 @@ import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.mongodb.management.internal.model.GenericNotificationConfigMongo;
 import io.gravitee.repository.mongodb.management.internal.notification.GenericNotificationConfigMongoRepository;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -85,8 +87,7 @@ public class MongoGenericNotificationConfigRepository implements GenericNotifica
     }
 
     @Override
-    public List<GenericNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<GenericNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId) {
         LOGGER.debug("Find GenericNotificationConfig [{}, {}, {}]", hook, referenceType, referenceId);
         return internalRepo
             .findByReferenceAndHook(hook, referenceType.name(), referenceId)
@@ -103,7 +104,7 @@ public class MongoGenericNotificationConfigRepository implements GenericNotifica
     }
 
     @Override
-    public void deleteByConfig(String config) throws TechnicalException {
+    public void deleteByConfig(String config) {
         LOGGER.debug("Delete GenericNotificationConfig by config [{}]", config);
         internalRepo.deleteByConfig(config);
     }
@@ -138,5 +139,12 @@ public class MongoGenericNotificationConfigRepository implements GenericNotifica
         cfg.setUpdatedAt(mongo.getUpdatedAt());
 
         return cfg;
+    }
+
+    @Override
+    public Set<GenericNotificationConfig> findAll() throws TechnicalException {
+        return internalRepo.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoInstallationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoInstallationRepository.java
@@ -21,11 +21,14 @@ import io.gravitee.repository.management.model.Installation;
 import io.gravitee.repository.mongodb.management.internal.installation.InstallationMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.InstallationMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -34,7 +37,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MongoInstallationRepository implements InstallationRepository {
 
-    private Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Autowired
     private InstallationMongoRepository internalRepository;
@@ -96,5 +99,12 @@ public class MongoInstallationRepository implements InstallationRepository {
 
     private Installation map(InstallationMongo installationMongoMongo) {
         return mapper.map(installationMongoMongo, Installation.class);
+    }
+
+    @Override
+    public Set<Installation> findAll() throws TechnicalException {
+        return internalRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
@@ -22,12 +22,15 @@ import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
 import io.gravitee.repository.mongodb.management.internal.membership.MembershipMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.MembershipMongo;
-import java.util.*;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -110,7 +113,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public void deleteMembers(MembershipReferenceType referenceType, String referenceId) throws TechnicalException {
+    public void deleteMembers(MembershipReferenceType referenceType, String referenceId) {
         logger.debug("Delete memberships [{}, {}]", referenceType, referenceId);
         internalMembershipRepo.deleteByRef(referenceType.name(), referenceId);
         logger.debug("Delete memberships [{}, {}] - Done", referenceType, referenceId);
@@ -127,7 +130,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByIds(Set<String> membershipIds) throws TechnicalException {
+    public Set<Membership> findByIds(Set<String> membershipIds) {
         logger.debug("Find membership by IDs [{}]", membershipIds);
 
         Set<Membership> memberships = internalMembershipRepo.findByIds(membershipIds).stream().map(this::map).collect(Collectors.toSet());
@@ -137,8 +140,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByReferenceAndRoleId(MembershipReferenceType referenceType, String referenceId, String roleId)
-        throws TechnicalException {
+    public Set<Membership> findByReferenceAndRoleId(MembershipReferenceType referenceType, String referenceId, String roleId) {
         logger.debug("Find membership by reference and roleId [{}, {}, {}]", referenceType, referenceId, roleId);
         Set<MembershipMongo> membershipMongos;
         if (roleId == null) {
@@ -152,8 +154,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByReferencesAndRoleId(MembershipReferenceType referenceType, List<String> referenceIds, String roleId)
-        throws TechnicalException {
+    public Set<Membership> findByReferencesAndRoleId(MembershipReferenceType referenceType, List<String> referenceIds, String roleId) {
         logger.debug("Find membership by references and roleId [{}, {}, {}]", referenceType, referenceIds, roleId);
         Set<MembershipMongo> membershipMongos;
         if (roleId == null) {
@@ -171,7 +172,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         String memberId,
         MembershipMemberType memberType,
         MembershipReferenceType referenceType
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by user and referenceType [{}, {}, {}]", memberId, memberType, referenceType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberTypeAndReferenceType(memberId, memberType.name(), referenceType.name())
@@ -183,7 +184,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByRoleId(String roleId) throws TechnicalException {
+    public Set<Membership> findByRoleId(String roleId) {
         logger.debug("Find membership by roleId [{}]", roleId);
         Set<Membership> memberships = internalMembershipRepo.findByRoleId(roleId).stream().map(this::map).collect(Collectors.toSet());
         logger.debug("Find membership by roleId [{}] = {}", roleId, memberships);
@@ -196,7 +197,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String roleId
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by user and referenceType and roleId [{}, {}, {}, {}]", memberId, memberType, referenceType, roleId);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberTypeAndReferenceTypeAndRoleId(memberId, memberType.name(), referenceType.name(), roleId)
@@ -220,7 +221,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String sourceId
-    ) throws TechnicalException {
+    ) {
         logger.debug(
             "Find membership by user and referenceType and sourceId [{}, {}, {}, {}]",
             memberId,
@@ -251,7 +252,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipReferenceType referenceType,
         String referenceId,
         String roleId
-    ) throws TechnicalException {
+    ) {
         logger.debug(
             "Find membership by user and referenceType and referenceId and roleId [{}, {}, {}, {}, {}]",
             memberId,
@@ -284,7 +285,7 @@ public class MongoMembershipRepository implements MembershipRepository {
     }
 
     @Override
-    public Set<Membership> findByMemberIdAndMemberType(String memberId, MembershipMemberType memberType) throws TechnicalException {
+    public Set<Membership> findByMemberIdAndMemberType(String memberId, MembershipMemberType memberType) {
         logger.debug("Find membership by user [{}, {}]", memberId, memberType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberType(memberId, memberType.name())
@@ -300,7 +301,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         List<String> memberIds,
         MembershipMemberType memberType,
         MembershipReferenceType referenceType
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by members and reference type [{}, {}, {}]", memberIds, memberType, referenceType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdsAndMemberTypeAndReferenceType(memberIds, memberType.name(), referenceType.name())
@@ -317,7 +318,7 @@ public class MongoMembershipRepository implements MembershipRepository {
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String referenceId
-    ) throws TechnicalException {
+    ) {
         logger.debug("Find membership by member and reference [{}, {}, {}, {}]", memberId, memberType, referenceId, referenceType);
         Set<Membership> memberships = internalMembershipRepo
             .findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(memberId, memberType.name(), referenceType.name(), referenceId)
@@ -360,5 +361,12 @@ public class MongoMembershipRepository implements MembershipRepository {
         membershipMongo.setCreatedAt(membership.getCreatedAt());
         membershipMongo.setUpdatedAt(membership.getUpdatedAt());
         return membershipMongo;
+    }
+
+    @Override
+    public Set<Membership> findAll() throws TechnicalException {
+        return internalMembershipRepo.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMetadataRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMetadataRepository.java
@@ -23,13 +23,15 @@ import io.gravitee.repository.management.model.MetadataReferenceType;
 import io.gravitee.repository.mongodb.management.internal.api.MetadataMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.MetadataMongo;
 import io.gravitee.repository.mongodb.management.internal.model.MetadataPkMongo;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -103,7 +105,7 @@ public class MongoMetadataRepository implements MetadataRepository {
     }
 
     @Override
-    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByReferenceType(MetadataReferenceType referenceType) {
         LOGGER.debug("Find metadata by ref type '{}'", referenceType);
 
         final List<MetadataMongo> metadata = internalMetadataRepository.findByIdReferenceType(referenceType);
@@ -113,8 +115,7 @@ public class MongoMetadataRepository implements MetadataRepository {
     }
 
     @Override
-    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<Metadata> findByReferenceTypeAndReferenceId(MetadataReferenceType referenceType, String referenceId) {
         LOGGER.debug("Find metadata by ref type '{}'", referenceType);
 
         final List<MetadataMongo> metadata = internalMetadataRepository.findByIdReferenceTypeAndIdReferenceId(referenceType, referenceId);
@@ -124,7 +125,7 @@ public class MongoMetadataRepository implements MetadataRepository {
     }
 
     @Override
-    public List<Metadata> findByKeyAndReferenceType(final String key, final MetadataReferenceType referenceType) throws TechnicalException {
+    public List<Metadata> findByKeyAndReferenceType(final String key, final MetadataReferenceType referenceType) {
         LOGGER.debug("Find metadata by key '{}' and ref type '{}'", key, referenceType);
 
         final List<MetadataMongo> metadata = internalMetadataRepository.findByIdKeyAndIdReferenceType(key, referenceType);
@@ -158,5 +159,12 @@ public class MongoMetadataRepository implements MetadataRepository {
         metadataMongo.setCreatedAt(metadata.getCreatedAt());
         metadataMongo.setUpdatedAt(metadata.getUpdatedAt());
         return metadataMongo;
+    }
+
+    @Override
+    public Set<Metadata> findAll() throws TechnicalException {
+        return internalMetadataRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoOrganizationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoOrganizationRepository.java
@@ -21,14 +21,14 @@ import io.gravitee.repository.management.model.Organization;
 import io.gravitee.repository.mongodb.management.internal.model.OrganizationMongo;
 import io.gravitee.repository.mongodb.management.internal.organization.OrganizationMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -119,13 +119,13 @@ public class MongoOrganizationRepository implements OrganizationRepository {
     }
 
     @Override
-    public List<Organization> findAll() throws TechnicalException {
+    public Set<Organization> findAll() throws TechnicalException {
         try {
             return internalOrganizationRepo
                 .findAll()
                 .stream()
                 .map(organization -> mapper.map(organization, Organization.class))
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
         } catch (Exception e) {
             LOGGER.error("An error occurred when counting organizations", e);
             throw new TechnicalException("An error occurred when counting organization");
@@ -133,7 +133,7 @@ public class MongoOrganizationRepository implements OrganizationRepository {
     }
 
     @Override
-    public Set<Organization> findByHrids(Set<String> hrids) throws TechnicalException {
+    public Set<Organization> findByHrids(Set<String> hrids) {
         final Set<OrganizationMongo> organizations = internalOrganizationRepo.findByHrids(hrids);
         return organizations
             .stream()

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRepository.java
@@ -130,8 +130,8 @@ public class MongoPageRepository implements PageRepository {
             PageMongo pageMongoUpdated = internalPageRepo.save(pageMongo);
             return mapper.map(pageMongoUpdated, Page.class);
         } catch (Exception e) {
-            logger.error("An error occured when updating page", e);
-            throw new TechnicalException("An error occured when updating page");
+            logger.error("An error occurred when updating page", e);
+            throw new TechnicalException("An error occurred when updating page");
         }
     }
 
@@ -154,8 +154,8 @@ public class MongoPageRepository implements PageRepository {
         try {
             internalPageRepo.deleteById(pageId);
         } catch (Exception e) {
-            logger.error("An error occured when deleting page [{}]", pageId, e);
-            throw new TechnicalException("An error occured when deleting page");
+            logger.error("An error occurred when deleting page [{}]", pageId, e);
+            throw new TechnicalException("An error occurred when deleting page");
         }
     }
 
@@ -165,8 +165,8 @@ public class MongoPageRepository implements PageRepository {
         try {
             return internalPageRepo.findMaxPageReferenceIdAndReferenceTypeOrder(referenceId, referenceType.name());
         } catch (Exception e) {
-            logger.error("An error occured when searching max order page for reference [{}, {}]", referenceId, referenceType, e);
-            throw new TechnicalException("An error occured when searching max order page for reference");
+            logger.error("An error occurred when searching max order page for reference [{}, {}]", referenceId, referenceType, e);
+            throw new TechnicalException("An error occurred when searching max order page for reference");
         }
     }
 
@@ -175,7 +175,7 @@ public class MongoPageRepository implements PageRepository {
         try {
             io.gravitee.common.data.domain.Page<PageMongo> page = internalPageRepo.findAll(pageable);
             List<Page> pageItems = mapper.collection2list(page.getContent(), PageMongo.class, Page.class);
-            return new io.gravitee.common.data.domain.Page<Page>(
+            return new io.gravitee.common.data.domain.Page<>(
                 pageItems,
                 page.getPageNumber(),
                 pageItems.size(),
@@ -207,5 +207,12 @@ public class MongoPageRepository implements PageRepository {
                 }
             )
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<Page> findAll() throws TechnicalException {
+        return internalPageRepo.findAll().stream()
+                .map(pageMongo -> mapper.map(pageMongo, Page.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRevisionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPageRevisionRepository.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.mongodb.management.internal.page.revision.PageRevi
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,5 +109,12 @@ public class MongoPageRevisionRepository implements PageRevisionRepository {
             logger.error("An error occurred when querying last revision for page [{}]", pageId, e);
             throw new TechnicalException("An error occurred when querying the last page revision");
         }
+    }
+
+    @Override
+    public Set<PageRevision> findAll() throws TechnicalException {
+        return internalPageRevisionRepo.findAll().stream()
+                .map(pageRevisionMongo -> mapper.map(pageRevisionMongo, PageRevision.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
@@ -21,12 +21,13 @@ import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.mongodb.management.internal.model.PlanMongo;
 import io.gravitee.repository.mongodb.management.internal.plan.PlanMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -42,12 +43,12 @@ public class MongoPlanRepository implements PlanRepository {
     private PlanMongoRepository internalPlanRepository;
 
     @Override
-    public List<Plan> findByApis(List<String> apiIds) throws TechnicalException {
+    public List<Plan> findByApis(List<String> apiIds) {
         return internalPlanRepository.findByApiIn(apiIds).stream().map(this::map).collect(Collectors.toList());
     }
 
     @Override
-    public Set<Plan> findByApi(String apiId) throws TechnicalException {
+    public Set<Plan> findByApi(String apiId) {
         return internalPlanRepository.findByApi(apiId).stream().map(this::map).collect(Collectors.toSet());
     }
 
@@ -92,5 +93,12 @@ public class MongoPlanRepository implements PlanRepository {
 
     private Plan map(PlanMongo planMongo) {
         return (planMongo == null) ? null : mapper.map(planMongo, Plan.class);
+    }
+
+    @Override
+    public Set<Plan> findAll() throws TechnicalException {
+        return internalPlanRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationConfigRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationConfigRepository.java
@@ -22,13 +22,15 @@ import io.gravitee.repository.management.model.PortalNotificationConfig;
 import io.gravitee.repository.mongodb.management.internal.model.PortalNotificationConfigMongo;
 import io.gravitee.repository.mongodb.management.internal.model.PortalNotificationConfigPkMongo;
 import io.gravitee.repository.mongodb.management.internal.notification.PortalNotificationConfigMongoRepository;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -81,8 +83,7 @@ public class MongoPortalNotificationConfigRepository implements PortalNotificati
     }
 
     @Override
-    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId)
-        throws TechnicalException {
+    public List<PortalNotificationConfig> findByReferenceAndHook(String hook, NotificationReferenceType referenceType, String referenceId) {
         LOGGER.debug("Find PortalNotificationConfigs [{}, {}, {}]", hook, referenceType, referenceId);
         return internalRepo
             .findByReferenceAndHook(hook, referenceType.name(), referenceId)
@@ -92,13 +93,13 @@ public class MongoPortalNotificationConfigRepository implements PortalNotificati
     }
 
     @Override
-    public void deleteByUser(String user) throws TechnicalException {
+    public void deleteByUser(String user) {
         LOGGER.debug("Delete PortalNotificationConfigs [{}]", user);
         internalRepo.deleteByUser(user);
     }
 
     @Override
-    public void deleteReference(NotificationReferenceType referenceType, String referenceId) throws TechnicalException {
+    public void deleteReference(NotificationReferenceType referenceType, String referenceId) {
         LOGGER.debug("Delete PortalNotificationConfigs [{}, {}]", referenceType, referenceId);
         internalRepo.deleteByReference(referenceType.name(), referenceId);
     }
@@ -129,5 +130,12 @@ public class MongoPortalNotificationConfigRepository implements PortalNotificati
         cfg.setUpdatedAt(mongo.getUpdatedAt());
 
         return cfg;
+    }
+
+    @Override
+    public Set<PortalNotificationConfig> findAll() throws TechnicalException {
+        return internalRepo.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalNotificationRepository.java
@@ -17,19 +17,19 @@ package io.gravitee.repository.mongodb.management;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNotificationRepository;
-import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.PortalNotification;
-import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.management.internal.model.PortalNotificationMongo;
 import io.gravitee.repository.mongodb.management.internal.notification.PortalNotificationMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -47,7 +47,7 @@ public class MongoPortalNotificationRepository implements PortalNotificationRepo
     private GraviteeMapper mapper;
 
     @Override
-    public List<PortalNotification> findByUser(String user) throws TechnicalException {
+    public List<PortalNotification> findByUser(String user) {
         LOGGER.debug("Find notifications by user: {}", user);
         return internalRepo.findByUser(user).stream().map(n -> mapper.map(n, PortalNotification.class)).collect(Collectors.toList());
     }
@@ -86,8 +86,15 @@ public class MongoPortalNotificationRepository implements PortalNotificationRepo
     }
 
     @Override
-    public void deleteAll(String user) throws TechnicalException {
+    public void deleteAll(String user) {
         LOGGER.debug("Delete notification for user : {}", user);
         internalRepo.deleteAll(user);
+    }
+
+    @Override
+    public Set<PortalNotification> findAll() throws TechnicalException {
+        return internalRepo.findAll().stream()
+                .map(this::mapPortalNotification)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPromotionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPromotionRepository.java
@@ -25,12 +25,15 @@ import io.gravitee.repository.management.model.Promotion;
 import io.gravitee.repository.mongodb.management.internal.model.PromotionMongo;
 import io.gravitee.repository.mongodb.management.internal.promotion.PromotionMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class MongoPromotionRepository implements PromotionRepository {
@@ -107,5 +110,12 @@ public class MongoPromotionRepository implements PromotionRepository {
 
         logger.debug("Searching promotions - Done");
         return new Page<>(content, promotions.getPageNumber(), (int) promotions.getPageElements(), promotions.getTotalElements());
+    }
+
+    @Override
+    public Set<Promotion> findAll() throws TechnicalException {
+        return internalRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingAnswerRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingAnswerRepository.java
@@ -15,20 +15,23 @@
  */
 package io.gravitee.repository.mongodb.management;
 
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toList;
-
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.RatingAnswerRepository;
 import io.gravitee.repository.management.model.RatingAnswer;
 import io.gravitee.repository.mongodb.management.internal.api.RatingAnswerMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.RatingAnswerMongo;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -119,5 +122,12 @@ public class MongoRatingAnswerRepository implements RatingAnswerRepository {
         ratingAnswerMongo.setComment(ratingAnswer.getComment());
         ratingAnswerMongo.setCreatedAt(ratingAnswer.getCreatedAt());
         return ratingAnswerMongo;
+    }
+
+    @Override
+    public Set<RatingAnswer> findAll() throws TechnicalException {
+        return internalRatingAnswerRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRatingRepository.java
@@ -15,9 +15,6 @@
  */
 package io.gravitee.repository.mongodb.management;
 
-import static java.util.Optional.ofNullable;
-import static java.util.stream.Collectors.toList;
-
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.RatingRepository;
@@ -26,14 +23,20 @@ import io.gravitee.repository.management.model.Rating;
 import io.gravitee.repository.management.model.RatingReferenceType;
 import io.gravitee.repository.mongodb.management.internal.api.RatingMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.RatingMongo;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toList;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -60,7 +63,7 @@ public class MongoRatingRepository implements RatingRepository {
         final String referenceId,
         final RatingReferenceType referenceType,
         final String user
-    ) throws TechnicalException {
+    ) {
         LOGGER.debug("Find rating by ref [{}] and user [{}]", referenceId, user);
         final RatingMongo rating = internalRatingRepository.findByReferenceIdAndReferenceTypeAndUser(
             referenceId,
@@ -84,7 +87,7 @@ public class MongoRatingRepository implements RatingRepository {
         final String referenceId,
         final RatingReferenceType referenceType,
         final Pageable pageable
-    ) throws TechnicalException {
+    ) {
         LOGGER.debug("Find rating by ref [{}] with pagination", referenceId);
         final org.springframework.data.domain.Page<RatingMongo> ratingPageMongo = internalRatingRepository.findByReferenceIdAndReferenceType(
             referenceId,
@@ -173,5 +176,12 @@ public class MongoRatingRepository implements RatingRepository {
         ratingMongo.setCreatedAt(rating.getCreatedAt());
         ratingMongo.setUpdatedAt(rating.getUpdatedAt());
         return ratingMongo;
+    }
+
+    @Override
+    public Set<Rating> findAll() throws TechnicalException {
+        return internalRatingRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
@@ -24,10 +24,13 @@ import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
 import io.gravitee.repository.mongodb.management.internal.plan.SubscriptionMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -103,5 +106,12 @@ public class MongoSubscriptionRepository implements SubscriptionRepository {
 
     private Subscription map(SubscriptionMongo subscriptionMongo) {
         return (subscriptionMongo == null) ? null : mapper.map(subscriptionMongo, Subscription.class);
+    }
+
+    @Override
+    public Set<Subscription> findAll() throws TechnicalException {
+        return internalSubscriptionRepository.findAll().stream()
+                .map(this::map)
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTagRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTagRepository.java
@@ -22,14 +22,15 @@ import io.gravitee.repository.management.model.TagReferenceType;
 import io.gravitee.repository.mongodb.management.internal.api.TagMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.TagMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -57,7 +58,7 @@ public class MongoTagRepository implements TagRepository {
     }
 
     @Override
-    public Optional<Tag> findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType) throws TechnicalException {
+    public Optional<Tag> findByIdAndReference(String tagId, String referenceId, TagReferenceType referenceType) {
         LOGGER.debug("Find tag by ID and reference [{}, {}, {}]", tagId, referenceId, referenceType);
 
         final TagMongo tag = internalTagRepo.findByIdAndReferenceIdAndReferenceType(tagId, referenceId, referenceType).orElse(null);
@@ -122,5 +123,12 @@ public class MongoTagRepository implements TagRepository {
     public Set<Tag> findByReference(String referenceId, TagReferenceType referenceType) throws TechnicalException {
         final List<TagMongo> tags = internalTagRepo.findByReferenceIdAndReferenceType(referenceId, referenceType);
         return tags.stream().map(tagMongo -> mapper.map(tagMongo, Tag.class)).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Tag> findAll() throws TechnicalException {
+        return internalTagRepo.findAll().stream()
+                .map(tagMongo -> mapper.map(tagMongo, Tag.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTenantRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTenantRepository.java
@@ -22,14 +22,15 @@ import io.gravitee.repository.management.model.TenantReferenceType;
 import io.gravitee.repository.mongodb.management.internal.api.TenantMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.TenantMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -57,8 +58,7 @@ public class MongoTenantRepository implements TenantRepository {
     }
 
     @Override
-    public Optional<Tenant> findByIdAndReference(String tenantId, String referenceId, TenantReferenceType referenceType)
-        throws TechnicalException {
+    public Optional<Tenant> findByIdAndReference(String tenantId, String referenceId, TenantReferenceType referenceType) {
         LOGGER.debug("Find tenant by ID [{}]", tenantId);
 
         final TenantMongo tenant = internalTenantRepo
@@ -105,8 +105,8 @@ public class MongoTenantRepository implements TenantRepository {
             TenantMongo tenantMongoUpdated = internalTenantRepo.save(tenantMongo);
             return mapper.map(tenantMongoUpdated, Tenant.class);
         } catch (Exception e) {
-            LOGGER.error("An error occured when updating tenant", e);
-            throw new TechnicalException("An error occured when updating tenant");
+            LOGGER.error("An error occurred when updating tenant", e);
+            throw new TechnicalException("An error occurred when updating tenant");
         }
     }
 
@@ -115,8 +115,8 @@ public class MongoTenantRepository implements TenantRepository {
         try {
             internalTenantRepo.deleteById(tenantId);
         } catch (Exception e) {
-            LOGGER.error("An error occured when deleting tenant [{}]", tenantId, e);
-            throw new TechnicalException("An error occured when deleting tenant");
+            LOGGER.error("An error occurred when deleting tenant [{}]", tenantId, e);
+            throw new TechnicalException("An error occurred when deleting tenant");
         }
     }
 
@@ -137,5 +137,12 @@ public class MongoTenantRepository implements TenantRepository {
                 }
             )
             .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Tenant> findAll() throws TechnicalException {
+        return internalTenantRepo.findAll().stream()
+                .map(tenantMongo -> mapper.map(tenantMongo, Tenant.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTicketRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoTicketRepository.java
@@ -25,12 +25,15 @@ import io.gravitee.repository.management.model.Ticket;
 import io.gravitee.repository.mongodb.management.internal.model.TicketMongo;
 import io.gravitee.repository.mongodb.management.internal.ticket.TicketMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
-import java.util.List;
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -82,5 +85,12 @@ public class MongoTicketRepository implements TicketRepository {
         LOGGER.debug("Search ticket {} - Done", ticketId);
 
         return Optional.ofNullable(mapper.map(ticket, Ticket.class));
+    }
+
+    @Override
+    public Set<Ticket> findAll() throws TechnicalException {
+        return internalTicketRepo.findAll().stream()
+                .map(ticketMongo -> mapper.map(ticketMongo, Ticket.class))
+                .collect(Collectors.toSet());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/OrganizationRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/OrganizationRepositoryMock.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.model.Organization;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -82,7 +83,7 @@ public class OrganizationRepositoryMock extends AbstractRepositoryMock<Organizat
         when(organizationRepository.findById("DEFAULT-ORG-findById")).thenReturn(of(orgFindById));
 
         when(organizationRepository.count()).thenReturn(4L);
-        when(organizationRepository.findAll()).thenReturn(Arrays.asList(orgCreate, orgUpdated, orgFindById, orgDefault));
+        when(organizationRepository.findAll()).thenReturn(Set.of(orgCreate, orgUpdated, orgFindById, orgDefault));
 
         when(organizationRepository.findByHrids(newSet("def", "ate"))).thenReturn(newSet(orgFindById, orgUpdated));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AlertEventRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AlertEventRepositoryProxy.java
@@ -21,8 +21,10 @@ import io.gravitee.repository.management.api.AlertEventRepository;
 import io.gravitee.repository.management.api.search.AlertEventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.AlertEvent;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -31,27 +33,38 @@ import org.springframework.stereotype.Component;
 @Component
 public class AlertEventRepositoryProxy extends AbstractProxy<AlertEventRepository> implements AlertEventRepository {
 
+    @Override
     public Page<AlertEvent> search(AlertEventCriteria criteria, Pageable pageable) {
         return target.search(criteria, pageable);
     }
 
+    @Override
     public void deleteAll(String alertId) {
         target.deleteAll(alertId);
     }
 
+    @Override
     public Optional<AlertEvent> findById(String s) throws TechnicalException {
         return target.findById(s);
     }
 
+    @Override
     public AlertEvent create(AlertEvent item) throws TechnicalException {
         return target.create(item);
     }
 
+    @Override
     public AlertEvent update(AlertEvent item) throws TechnicalException {
         return target.update(item);
     }
 
+    @Override
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<AlertEvent> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiKeyRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiKeyRepositoryProxy.java
@@ -19,10 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.ApiKey;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -69,5 +70,10 @@ public class ApiKeyRepositoryProxy extends AbstractProxy<ApiKeyRepository> imple
     @Override
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException {
         return target.findByCriteria(filter);
+    }
+
+    @Override
+    public Set<ApiKey> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiQualityRuleRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiQualityRuleRepositoryProxy.java
@@ -18,9 +18,11 @@ package io.gravitee.rest.api.repository.proxy;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.model.ApiQualityRule;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -67,5 +69,10 @@ public class ApiQualityRuleRepositoryProxy extends AbstractProxy<ApiQualityRuleR
     @Override
     public void deleteByApi(String api) throws TechnicalException {
         target.deleteByApi(api);
+    }
+
+    @Override
+    public Set<ApiQualityRule> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -24,6 +24,9 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Api;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+
+import io.gravitee.repository.management.model.ApiQualityRule;
 import org.springframework.stereotype.Component;
 
 /**
@@ -67,5 +70,10 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     @Override
     public List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
         return target.search(apiCriteria, apiFieldExclusionFilter);
+    }
+
+    @Override
+    public Set<Api> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApplicationRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApplicationRepositoryProxy.java
@@ -22,10 +22,11 @@ import io.gravitee.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -83,5 +84,10 @@ public class ApplicationRepositoryProxy extends AbstractProxy<ApplicationReposit
     @Override
     public Set<Application> findAllByEnvironment(String environment, ApplicationStatus... statuses) throws TechnicalException {
         return target.findAllByEnvironment(environment, statuses);
+    }
+
+    @Override
+    public Set<Application> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AuditRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/AuditRepositoryProxy.java
@@ -21,8 +21,10 @@ import io.gravitee.repository.management.api.AuditRepository;
 import io.gravitee.repository.management.api.search.AuditCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Audit;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -54,5 +56,10 @@ public class AuditRepositoryProxy extends AbstractProxy<AuditRepository> impleme
     @Override
     public Page<Audit> search(AuditCriteria filter, Pageable pageable) {
         return target.search(filter, pageable);
+    }
+
+    @Override
+    public Set<Audit> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CommandRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CommandRepositoryProxy.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.api.search.CommandCriteria;
 import io.gravitee.repository.management.model.Command;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -53,5 +55,10 @@ public class CommandRepositoryProxy extends AbstractProxy<CommandRepository> imp
     @Override
     public List<Command> search(CommandCriteria criteria) {
         return target.search(criteria);
+    }
+
+    @Override
+    public Set<Command> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CustomUserFieldsRespositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/CustomUserFieldsRespositoryProxy.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CustomUserFieldsRepository;
 import io.gravitee.repository.management.model.CustomUserField;
 import io.gravitee.repository.management.model.CustomUserFieldReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -54,5 +56,10 @@ public class CustomUserFieldsRespositoryProxy extends AbstractProxy<CustomUserFi
     public List<CustomUserField> findByReferenceIdAndReferenceType(String refId, CustomUserFieldReferenceType refType)
         throws TechnicalException {
         return target.findByReferenceIdAndReferenceType(refId, refType);
+    }
+
+    @Override
+    public Set<CustomUserField> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/EntrypointRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/EntrypointRepositoryProxy.java
@@ -19,9 +19,10 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EntrypointRepository;
 import io.gravitee.repository.management.model.Entrypoint;
 import io.gravitee.repository.management.model.EntrypointReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
@@ -59,5 +60,10 @@ public class EntrypointRepositoryProxy extends AbstractProxy<EntrypointRepositor
     @Override
     public Set<Entrypoint> findByReference(String referenceId, EntrypointReferenceType referenceType) throws TechnicalException {
         return target.findByReference(referenceId, referenceType);
+    }
+
+    @Override
+    public Set<Entrypoint> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/EventRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/EventRepositoryProxy.java
@@ -21,10 +21,11 @@ import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Event;
-import io.gravitee.repository.management.model.EventType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -66,5 +67,10 @@ public class EventRepositoryProxy extends AbstractProxy<EventRepository> impleme
     @Override
     public List<Event> search(EventCriteria filter) {
         return target.search(filter);
+    }
+
+    @Override
+    public Set<Event> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/FlowRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/FlowRepositoryProxy.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.FlowRepository;
 import io.gravitee.repository.management.model.flow.Flow;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -58,5 +60,10 @@ public class FlowRepositoryProxy extends AbstractProxy<FlowRepository> implement
     @Override
     public void delete(String id) throws TechnicalException {
         target.delete(id);
+    }
+
+    @Override
+    public Set<Flow> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/GenericNotificationConfigRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/GenericNotificationConfigRepositoryProxy.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.GenericNotificationConfigRepository;
 import io.gravitee.repository.management.model.GenericNotificationConfig;
 import io.gravitee.repository.management.model.NotificationReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -67,5 +69,10 @@ public class GenericNotificationConfigRepositoryProxy
     @Override
     public void deleteByConfig(String config) throws TechnicalException {
         target.deleteByConfig(config);
+    }
+
+    @Override
+    public Set<GenericNotificationConfig> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/InstallationRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/InstallationRepositoryProxy.java
@@ -18,8 +18,10 @@ package io.gravitee.rest.api.repository.proxy;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InstallationRepository;
 import io.gravitee.repository.management.model.Installation;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -51,5 +53,10 @@ public class InstallationRepositoryProxy extends AbstractProxy<InstallationRepos
     @Override
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<Installation> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MembershipRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MembershipRepositoryProxy.java
@@ -20,10 +20,11 @@ import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -147,5 +148,10 @@ public class MembershipRepositoryProxy extends AbstractProxy<MembershipRepositor
         String referenceId
     ) throws TechnicalException {
         return target.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(memberId, memberType, referenceType, referenceId);
+    }
+
+    @Override
+    public Set<Membership> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MetadataRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MetadataRepositoryProxy.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.MetadataRepository;
 import io.gravitee.repository.management.model.Metadata;
 import io.gravitee.repository.management.model.MetadataReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
@@ -64,5 +66,10 @@ public class MetadataRepositoryProxy extends AbstractProxy<MetadataRepository> i
     @Override
     public List<Metadata> findByKeyAndReferenceType(String key, MetadataReferenceType referenceType) throws TechnicalException {
         return target.findByKeyAndReferenceType(key, referenceType);
+    }
+
+    @Override
+    public Set<Metadata> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/OrganizationRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/OrganizationRepositoryProxy.java
@@ -18,10 +18,10 @@ package io.gravitee.rest.api.repository.proxy;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
-import java.util.Collection;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -56,7 +56,7 @@ public class OrganizationRepositoryProxy extends AbstractProxy<OrganizationRepos
     }
 
     @Override
-    public Collection<Organization> findAll() throws TechnicalException {
+    public Set<Organization> findAll() throws TechnicalException {
         return target.findAll();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRepositoryProxy.java
@@ -21,9 +21,11 @@ import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -68,5 +70,10 @@ public class PageRepositoryProxy extends AbstractProxy<PageRepository> implement
     @Override
     public io.gravitee.common.data.domain.Page<Page> findAll(Pageable pageable) throws TechnicalException {
         return target.findAll(pageable);
+    }
+
+    @Override
+    public Set<Page> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRevisionRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PageRevisionRepositoryProxy.java
@@ -17,15 +17,14 @@ package io.gravitee.rest.api.repository.proxy;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PageRevisionRepository;
-import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
-import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.repository.management.model.PageRevision;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -57,5 +56,10 @@ public class PageRevisionRepositoryProxy extends AbstractProxy<PageRevisionRepos
     @Override
     public Optional<PageRevision> findById(String pageId, int revision) throws TechnicalException {
         return target.findById(pageId, revision);
+    }
+
+    @Override
+    public Set<PageRevision> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ParameterRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ParameterRepositoryProxy.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ParameterRepository;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
@@ -59,5 +61,10 @@ public class ParameterRepositoryProxy extends AbstractProxy<ParameterRepository>
     @Override
     public List<Parameter> findAll(String referenceId, ParameterReferenceType referenceType) throws TechnicalException {
         return target.findAll(referenceId, referenceType);
+    }
+
+    @Override
+    public Set<Parameter> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PlanRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PlanRepositoryProxy.java
@@ -18,10 +18,11 @@ package io.gravitee.rest.api.repository.proxy;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -35,23 +36,33 @@ public class PlanRepositoryProxy extends AbstractProxy<PlanRepository> implement
         return target.findByApis(apiIds);
     }
 
+    @Override
     public Set<Plan> findByApi(String apiId) throws TechnicalException {
         return target.findByApi(apiId);
     }
 
+    @Override
     public Optional<Plan> findById(String s) throws TechnicalException {
         return target.findById(s);
     }
 
+    @Override
     public Plan create(Plan item) throws TechnicalException {
         return target.create(item);
     }
 
+    @Override
     public Plan update(Plan item) throws TechnicalException {
         return target.update(item);
     }
 
+    @Override
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<Plan> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationConfigRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationConfigRepositoryProxy.java
@@ -19,9 +19,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
 import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.PortalNotificationConfig;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -67,5 +69,10 @@ public class PortalNotificationConfigRepositoryProxy
     @Override
     public void deleteReference(NotificationReferenceType referenceType, String referenceId) throws TechnicalException {
         target.deleteReference(referenceType, referenceId);
+    }
+
+    @Override
+    public Set<PortalNotificationConfig> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PortalNotificationRepositoryProxy.java
@@ -18,9 +18,11 @@ package io.gravitee.rest.api.repository.proxy;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalNotificationRepository;
 import io.gravitee.repository.management.model.PortalNotification;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -62,5 +64,10 @@ public class PortalNotificationRepositoryProxy extends AbstractProxy<PortalNotif
     @Override
     public void deleteAll(String s) throws TechnicalException {
         target.deleteAll(s);
+    }
+
+    @Override
+    public Set<PortalNotification> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PromotionRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PromotionRepositoryProxy.java
@@ -22,8 +22,10 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.PromotionCriteria;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Promotion;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
 
 @Component
 public class PromotionRepositoryProxy extends AbstractProxy<PromotionRepository> implements PromotionRepository {
@@ -51,5 +53,10 @@ public class PromotionRepositoryProxy extends AbstractProxy<PromotionRepository>
     @Override
     public Page<Promotion> search(PromotionCriteria criteria, Sortable sortable, Pageable pageable) throws TechnicalException {
         return target.search(criteria, sortable, pageable);
+    }
+
+    @Override
+    public Set<Promotion> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingAnswerRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingAnswerRepositoryProxy.java
@@ -18,9 +18,11 @@ package io.gravitee.rest.api.repository.proxy;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.RatingAnswerRepository;
 import io.gravitee.repository.management.model.RatingAnswer;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -52,5 +54,10 @@ public class RatingAnswerRepositoryProxy extends AbstractProxy<RatingAnswerRepos
     @Override
     public void delete(String id) throws TechnicalException {
         target.delete(id);
+    }
+
+    @Override
+    public Set<RatingAnswer> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/RatingRepositoryProxy.java
@@ -21,9 +21,11 @@ import io.gravitee.repository.management.api.RatingRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Rating;
 import io.gravitee.repository.management.model.RatingReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -67,5 +69,10 @@ public class RatingRepositoryProxy extends AbstractProxy<RatingRepository> imple
     public Optional<Rating> findByReferenceIdAndReferenceTypeAndUser(String referenceId, RatingReferenceType referenceType, String user)
         throws TechnicalException {
         return target.findByReferenceIdAndReferenceTypeAndUser(referenceId, referenceType, user);
+    }
+
+    @Override
+    public Set<Rating> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/SubscriptionRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/SubscriptionRepositoryProxy.java
@@ -21,9 +21,11 @@ import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
+import java.util.Set;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -56,5 +58,10 @@ public class SubscriptionRepositoryProxy extends AbstractProxy<SubscriptionRepos
 
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<Subscription> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TagRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TagRepositoryProxy.java
@@ -19,9 +19,10 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TagRepository;
 import io.gravitee.repository.management.model.Tag;
 import io.gravitee.repository.management.model.TagReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author Azize ELAMRANI (azize at graviteesource.com)
@@ -58,5 +59,10 @@ public class TagRepositoryProxy extends AbstractProxy<TagRepository> implements 
     @Override
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<Tag> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TenantRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TenantRepositoryProxy.java
@@ -19,9 +19,10 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TenantRepository;
 import io.gravitee.repository.management.model.Tenant;
 import io.gravitee.repository.management.model.TenantReferenceType;
+import org.springframework.stereotype.Component;
+
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -59,5 +60,10 @@ public class TenantRepositoryProxy extends AbstractProxy<TenantRepository> imple
     @Override
     public void delete(String s) throws TechnicalException {
         target.delete(s);
+    }
+
+    @Override
+    public Set<Tenant> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TicketRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/TicketRepositoryProxy.java
@@ -22,8 +22,10 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.TicketCriteria;
 import io.gravitee.repository.management.model.Ticket;
-import java.util.Optional;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -45,5 +47,10 @@ public class TicketRepositoryProxy extends AbstractProxy<TicketRepository> imple
     @Override
     public Optional<Ticket> findById(String ticketId) throws TechnicalException {
         return target.findById(ticketId);
+    }
+
+    @Override
+    public Set<Ticket> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/UserRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/UserRepositoryProxy.java
@@ -21,10 +21,11 @@ import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.management.model.User;
+import org.springframework.stereotype.Component;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.springframework.stereotype.Component;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -72,5 +73,10 @@ public class UserRepositoryProxy extends AbstractProxy<UserRepository> implement
     @Override
     public void delete(String id) throws TechnicalException {
         target.delete(id);
+    }
+
+    @Override
+    public Set<User> findAll() throws TechnicalException {
+        return target.findAll();
     }
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6035

Add requirements for mongo->jdbc database migration tool :
- all repositories extends the findAll() function
- add the NoOpDatasource, that can be enabled with `jdbc.sqlOnly` parameter, to log SQL queries to a file
