### PR TITLE
fix: fix SearchIndexUpgrader multi-environments management

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import java.util.Comparator;
@@ -63,7 +64,7 @@ public class CategoriesResource extends AbstractCategoryResource {
         // We should find a way to load total API only when necessary (ie. not while editing an API)
         Set<ApiEntity> apis;
         if (isAdmin()) {
-            apis = apiService.findAll();
+            apis = apiService.findAllByEnvironment(GraviteeContext.getCurrentEnvironment());
         } else if (isAuthenticated()) {
             apis = apiService.findByUser(getAuthenticatedUser(), null, true);
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -37,7 +37,9 @@ import java.util.Set;
 public interface ApiService {
     ApiEntity findById(String apiId);
 
-    Set<ApiEntity> findAll();
+    Set<ApiEntity> findAllByEnvironment(String environment);
+
+    Set<ApiEntity> findAllLightByEnvironment(String environmentId);
 
     Set<ApiEntity> findAllLight();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
@@ -37,6 +37,8 @@ public interface PageService {
 
     List<PageEntity> search(PageQuery query, String environmentId);
 
+    List<PageEntity> search(PageQuery query, boolean withTranslations);
+
     List<PageEntity> search(PageQuery query, boolean withTranslations, String environmentId);
 
     List<PageEntity> search(PageQuery query, String acceptedLocale, String environmentId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -947,38 +947,37 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     @Override
-    public Set<ApiEntity> findAll() {
+    public Set<ApiEntity> findAllByEnvironment(String environmentId) {
         try {
-            LOGGER.debug("Find all APIs for current environment {}", GraviteeContext.getCurrentEnvironment());
-            return new HashSet<>(
-                convert(apiRepository.search(new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build()))
-            );
+            LOGGER.debug("Find all APIs for environment {}", environmentId);
+            return new HashSet<>(convert(apiRepository.search(new ApiCriteria.Builder().environmentId(environmentId).build())));
         } catch (TechnicalException ex) {
-            LOGGER.error(
-                "An error occurs while trying to find all APIs for current environment {}",
-                GraviteeContext.getCurrentEnvironment(),
-                ex
-            );
-            throw new TechnicalManagementException("An error occurs while trying to find all APIs for current environment", ex);
+            LOGGER.error("An error occurs while trying to find all APIs for environment {}", environmentId, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find all APIs for environment", ex);
         }
     }
 
     @Override
-    public Set<ApiEntity> findAllLight() {
+    public Set<ApiEntity> findAllLightByEnvironment(String environmentId) {
         try {
-            LOGGER.debug("Find all APIs without some fields (definition, picture...)");
+            LOGGER.debug("Find all APIs without some fields (definition, picture...) for environment {}", environmentId);
             return new HashSet<>(
                 convert(
                     apiRepository.search(
-                        new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                        new ApiCriteria.Builder().environmentId(environmentId).build(),
                         new ApiFieldExclusionFilter.Builder().excludeDefinition().excludePicture().build()
                     )
                 )
             );
         } catch (TechnicalException ex) {
-            LOGGER.error("An error occurs while trying to find all APIs light", ex);
-            throw new TechnicalManagementException("An error occurs while trying to find all APIs light", ex);
+            LOGGER.error("An error occurs while trying to find all APIs light for environment {}", environmentId, ex);
+            throw new TechnicalManagementException("An error occurs while trying to find all APIs light for environment", ex);
         }
+    }
+
+    @Override
+    public Set<ApiEntity> findAllLight() {
+        return findAllLightByEnvironment(null);
     }
 
     @Override
@@ -2578,7 +2577,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     @Override
     public void deleteCategoryFromAPIs(final String categoryId) {
-        findAll()
+        findAllByEnvironment(GraviteeContext.getCurrentEnvironment())
             .forEach(
                 api -> {
                     if (api.getCategories() != null && api.getCategories().contains(categoryId)) {
@@ -2610,7 +2609,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     @Override
     public void deleteTagFromAPIs(final String tagId) {
-        findAll()
+        findAllByEnvironment(GraviteeContext.getCurrentEnvironment())
             .forEach(
                 api -> {
                     if (api.getTags() != null && api.getTags().contains(tagId)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -546,6 +546,11 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     @Override
+    public List<PageEntity> search(final PageQuery query, boolean withTranslations) {
+        return this.search(query, null, withTranslations, true, null);
+    }
+
+    @Override
     public List<PageEntity> search(final PageQuery query, boolean withTranslations, String environmentId) {
         return this.search(query, null, withTranslations, true, environmentId);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgrader.java
@@ -81,7 +81,7 @@ public class DocumentationSystemFolderUpgrader implements Upgrader, Ordered {
 
             // Apis documentation
             apiService
-                .findAllLight()
+                .findAllLightByEnvironment(GraviteeContext.getCurrentEnvironment())
                 .forEach(
                     api -> pageService.createSystemFolder(api.getId(), SystemFolderType.ASIDE, 0, GraviteeContext.getDefaultEnvironment())
                 );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.upgrade;
 
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.management.model.UserStatus;
 import io.gravitee.rest.api.model.PageEntity;
@@ -29,12 +30,12 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.Ordered;
 import org.springframework.stereotype.Component;
@@ -46,6 +47,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class SearchIndexUpgrader implements Upgrader, Ordered {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SearchIndexUpgrader.class);
 
     @Autowired
     private ApiService apiService;
@@ -60,115 +63,120 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
     private SearchEngineService searchEngineService;
 
     @Autowired
-    private OrganizationService organizationService;
+    private EnvironmentRepository environmentRepository;
 
-    @Autowired
-    private EnvironmentService environmentService;
+    private final Map<String, String> organizationIdByEnvironmentIdMap = new ConcurrentHashMap<>();
 
     @Override
     public boolean upgrade() {
-        try {
-            organizationService
-                .findAll()
-                .forEach(
-                    organization ->
-                        environmentService
-                            .findByOrganization(organization.getId())
-                            .forEach(
-                                environment -> {
-                                    GraviteeContext.setCurrentOrganization(organization.getId());
-                                    GraviteeContext.setCurrentEnvironment(environment.getId());
+        ExecutorService executorService = Executors.newFixedThreadPool(
+            Runtime.getRuntime().availableProcessors() * 2,
+            new ThreadFactory() {
+                private final AtomicLong counter = new AtomicLong(0);
 
-                                    // Index APIs
-                                    final Set<ApiEntity> apis = apiService.findAllLight();
+                @Override
+                public Thread newThread(@NotNull Runnable r) {
+                    return new Thread(r, "gio.search-indexer-upgrader-" + counter.getAndIncrement());
+                }
+            }
+        );
 
-                                    ExecutorService executorService = Executors.newFixedThreadPool(
-                                        Runtime.getRuntime().availableProcessors() * 2,
-                                        new ThreadFactory() {
-                                            private final AtomicLong counter = new AtomicLong(0);
+        List<CompletableFuture<?>> futures = new ArrayList<>();
 
-                                            @Override
-                                            public Thread newThread(@NotNull Runnable r) {
-                                                return new Thread(r, "gio.search-indexer-upgrader-" + counter.getAndIncrement());
-                                            }
-                                        }
-                                    );
+        // index APIs
+        apiService
+            .findAllLight()
+            .stream()
+            .forEach(
+                apiEntity -> {
+                    String environmentId = apiEntity.getReferenceId();
+                    String organizationId = organizationIdByEnvironmentIdMap.computeIfAbsent(
+                        environmentId,
+                        envId -> {
+                            try {
+                                return environmentRepository.findById(environmentId).get().getOrganizationId();
+                            } catch (Exception e) {
+                                LOGGER.error("failed to find organization for environment {}", environmentId, e);
+                                return null;
+                            }
+                        }
+                    );
 
-                                    List<CompletableFuture<?>> futures = new ArrayList<>();
-                                    apis
-                                        .stream()
-                                        .forEach(
-                                            new Consumer<ApiEntity>() {
-                                                @Override
-                                                public void accept(ApiEntity apiEntity) {
-                                                    futures.add(
-                                                        CompletableFuture.runAsync(
-                                                            () -> {
-                                                                // API
-                                                                searchEngineService.index(apiEntity, true, false);
+                    futures.add(runApiIndexationAsync(apiEntity, environmentId, organizationId, executorService));
+                }
+            );
 
-                                                                // Pages
-                                                                List<PageEntity> apiPages = pageService.search(
-                                                                    new PageQuery.Builder().api(apiEntity.getId()).published(true).build(),
-                                                                    true,
-                                                                    GraviteeContext.getCurrentEnvironment()
-                                                                );
-                                                                apiPages.forEach(
-                                                                    page -> {
-                                                                        try {
-                                                                            if (
-                                                                                !PageType.FOLDER.name().equals(page.getType()) &&
-                                                                                !PageType.ROOT.name().equals(page.getType()) &&
-                                                                                !PageType.SYSTEM_FOLDER.name().equals(page.getType()) &&
-                                                                                !PageType.LINK.name().equals(page.getType())
-                                                                            ) {
-                                                                                pageService.transformSwagger(page, apiEntity.getId());
-                                                                                searchEngineService.index(page, true, false);
-                                                                            }
-                                                                        } catch (Exception ignored) {}
-                                                                    }
-                                                                );
-                                                            },
-                                                            executorService
-                                                        )
-                                                    );
-                                                }
-                                            }
-                                        );
+        // index users
+        futures.add(runUsersIndexationAsync());
 
-                                    futures.add(
-                                        CompletableFuture.runAsync(
-                                            () -> {
-                                                // Index users
-                                                Page<UserEntity> users = userService.search(
-                                                    new UserCriteria.Builder().statuses(UserStatus.ACTIVE).build(),
-                                                    new PageableImpl(1, Integer.MAX_VALUE)
-                                                );
+        CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
 
-                                                users
-                                                    .getContent()
-                                                    .forEach(userEntity -> searchEngineService.index(userEntity, true, false));
-                                            }
-                                        )
-                                    );
-
-                                    CompletableFuture<Void> future = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
-
-                                    future.whenCompleteAsync(
-                                        (unused, throwable) -> {
-                                            executorService.shutdown();
-                                            searchEngineService.commit();
-                                        },
-                                        executorService
-                                    );
-                                }
-                            )
-                );
-        } finally {
-            GraviteeContext.cleanContext();
-        }
+        future.whenCompleteAsync(
+            (unused, throwable) -> {
+                executorService.shutdown();
+                searchEngineService.commit();
+            },
+            executorService
+        );
 
         return true;
+    }
+
+    private CompletableFuture runApiIndexationAsync(
+        ApiEntity apiEntity,
+        String environmentId,
+        String organizationId,
+        ExecutorService executorService
+    ) {
+        return CompletableFuture.runAsync(
+            () -> {
+                try {
+                    GraviteeContext.setCurrentEnvironment(environmentId);
+                    GraviteeContext.setCurrentOrganization(organizationId);
+
+                    // API
+                    searchEngineService.index(apiEntity, true, false);
+
+                    // Pages
+                    List<PageEntity> apiPages = pageService.search(
+                        new PageQuery.Builder().api(apiEntity.getId()).published(true).build(),
+                        true
+                    );
+                    apiPages.forEach(
+                        page -> {
+                            try {
+                                if (
+                                    !PageType.FOLDER.name().equals(page.getType()) &&
+                                    !PageType.ROOT.name().equals(page.getType()) &&
+                                    !PageType.SYSTEM_FOLDER.name().equals(page.getType()) &&
+                                    !PageType.LINK.name().equals(page.getType())
+                                ) {
+                                    pageService.transformSwagger(page, apiEntity.getId());
+                                    searchEngineService.index(page, true, false);
+                                }
+                            } catch (Exception ignored) {}
+                        }
+                    );
+                } finally {
+                    GraviteeContext.cleanContext();
+                }
+            },
+            executorService
+        );
+    }
+
+    private CompletableFuture runUsersIndexationAsync() {
+        return CompletableFuture.runAsync(
+            () -> {
+                // Index users
+                Page<UserEntity> users = userService.search(
+                    new UserCriteria.Builder().statuses(UserStatus.ACTIVE).build(),
+                    new PageableImpl(1, Integer.MAX_VALUE)
+                );
+
+                users.getContent().forEach(userEntity -> searchEngineService.index(userEntity, true, false));
+            }
+        );
     }
 
     @Override


### PR DESCRIPTION
Fix SearchIndexUpgrader mutli environments and organizations management :
GraviteeContext's environments and organizations were set outside of thread using them.

Instead of looping on environments, find all APIs in database, for all environments, and set GraviteeContext's environments and organizations in the aync thread.

It has to be improved soon, has we :
- don't load all APIs in memory (pagination)
- don't re-read APIs in subsequent called services
- don't use GraviteeContext, but provide environment/organization in parameters