### PR TITLE
chore: skip node install & assembly task when skipping npm execution

### DIFF
--- a/gravitee-apim-console-webui/pom.xml
+++ b/gravitee-apim-console-webui/pom.xml
@@ -123,6 +123,7 @@
             <configuration>
               <nodeVersion>${node.version}</nodeVersion>
               <npmVersion>${npm.version}</npmVersion>
+              <skip>${skip.npm}</skip>
             </configuration>
           </execution>
           <execution>
@@ -192,6 +193,7 @@
               <descriptors>
                 <descriptor>assembly.xml</descriptor>
               </descriptors>
+              <skipAssembly>${skip.npm}</skipAssembly>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Since our newcomer, the build with the skipTests option is very long... it downloads npm and build in production mode 
With the option `-Dskip.npm` we save time and preserve the planet