### PR TITLE
fix: bump gravitee-license-node.version to 1.3.0-SNAPSHOT fixes policies licenses issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-expression-language.version>1.7.1-SNAPSHOT</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.28.0</gravitee-gateway-api.version>
-        <gravitee-license-node.version>1.1.0</gravitee-license-node.version>
+        <gravitee-license-node.version>1.3.0-SNAPSHOT</gravitee-license-node.version>
         <gravitee-node.version>1.17.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.20.0-SNAPSHOT</gravitee-plugin.version>


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6435