### PR TITLE
Change FROM image in Dockerfiles

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile-dev
+++ b/gravitee-apim-console-webui/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM alpine:3 AS build-env
+FROM alpine:3.14 AS build-env
 LABEL maintainer="contact@graviteesource.com"
 
 ADD dist dist

--- a/gravitee-apim-portal-webui/docker/Dockerfile-dev
+++ b/gravitee-apim-portal-webui/docker/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM alpine:3 AS build-env
+FROM alpine:3.14 AS build-env
 LABEL maintainer="contact@graviteesource.com"
 
 ADD dist dist

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
We are migrating to `eclipse-temurin:11-jre-focal` as it provides better security then the `openjdk:11-jre-slim-buster` FROM image.

 Additionally, we are using versioned FROM images i.e. Alpine.