### PR TITLE
chore: remove `dist` folder from .dockerignore

### DIFF
--- a/gravitee-apim-portal-webui/.dockerignore
+++ b/gravitee-apim-portal-webui/.dockerignore
@@ -1,7 +1,6 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist
 /tmp
 /out-tsc
 # Only exists if Bazel was run


### PR DESCRIPTION
**Issue**

NA

**Description**

Remove `dist` folder from .dockerignore as we are using the dist folder to build the dev image (this change has been lost during the 3.12.x -> master merge)
