### PR TITLE
Update `swagger-ui-dist` to 3.52.5 

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -34531,9 +34531,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.52.3",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.3.tgz",
-      "integrity": "sha512-7QSY4milmYx5O8dbzU5tTftiaoZt+4JGxahTTBiLAnbTvhTyzum9rsjDIJjC+xeT8Tt1KfB38UuQQjmrh2THDQ=="
+      "version": "3.52.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz",
+      "integrity": "sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw=="
     },
     "symbol-observable": {
       "version": "1.2.0",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -72,7 +72,7 @@
     "showdown": "^1.9.1",
     "showdown-highlightjs-extension": "^0.1.2",
     "showdown-prettify": "^1.3.0",
-    "swagger-ui-dist": "^3.52.3",
+    "swagger-ui-dist": "^3.52.5",
     "tinycolor2": "^1.4.2",
     "traverse": "^0.6.6",
     "unicode": "^11.0.1",

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -17290,9 +17290,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.0.tgz",
-      "integrity": "sha512-vwvJPPbdooTvDwLGzjIXinOXizDJJ6U1hxnJL3y6U3aL1d2MSXDmKg2139XaLBhsVZdnQJV2bOkX4reB+RXamg=="
+      "version": "3.52.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.52.5.tgz",
+      "integrity": "sha512-8z18eX8G/jbTXYzyNIaobrnD7PSN7yU/YkSasMmajrXtw0FGS64XjrKn5v37d36qmU3o1xLeuYnktshRr7uIFw=="
     },
     "swagger2openapi": {
       "version": "6.2.3",

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -56,7 +56,7 @@
     "redoc": "^2.0.0-rc.53",
     "resize-observer-polyfill": "^1.5.1",
     "rxjs": "6.5.5",
-    "swagger-ui-dist": "^3.25.0",
+    "swagger-ui-dist": "^3.52.5",
     "tslib": "^1.11.1",
     "zone.js": "~0.10.2"
   },


### PR DESCRIPTION
**Issue**

NA

**Description**

Update `swagger-ui-dist` to 3.52.5 and use the same version for Console and Portal to ensure consistency across these 2 apps.

**Additional context**

Replace https://github.com/gravitee-io/gravitee-portal-webui/pull/455 and https://github.com/gravitee-io/gravitee-portal-webui/pull/440

cc @MTigra
