### PR TITLE
fix(portal): fix logs filter by path on application's logs screen

### DIFF
--- a/gravitee-apim-portal-webui/src/app/services/analytics.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/analytics.service.spec.ts
@@ -17,7 +17,6 @@ import { TestBed } from '@angular/core/testing';
 import { TranslateTestingModule } from '../test/translate-testing-module';
 
 import { AnalyticsService } from './analytics.service';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 describe('AnalyticsService', () => {
@@ -30,5 +29,27 @@ describe('AnalyticsService', () => {
   it('should be created', () => {
     const service: AnalyticsService = TestBed.inject(AnalyticsService);
     expect(service).toBeTruthy();
+  });
+
+  describe('buildQueryParam()', () => {
+    it('should use "starts with" wildcard for uri parameter', () => {
+      const resultQueryParam = AnalyticsService.buildQueryParam('/test/uri?bala=test', 'uri');
+      expect(resultQueryParam).toBe('\\\\/test\\\\/uri\\\\?bala\\\\=test*');
+    });
+
+    it('should use "contains" wildcard for body parameter', () => {
+      const resultQueryParam = AnalyticsService.buildQueryParam('part of body content', 'body');
+      expect(resultQueryParam).toBe('*part of body content*');
+    });
+
+    it('should use quotes for other parameters', () => {
+      const resultQueryParam = AnalyticsService.buildQueryParam('exact = text * search', 'another');
+      expect(resultQueryParam).toBe('\\"exact = text * search\\"');
+    });
+
+    it('should not quote the "?" wildcard', () => {
+      const resultQueryParam = AnalyticsService.buildQueryParam('?', 'another');
+      expect(resultQueryParam).toBe('?');
+    });
   });
 });

--- a/gravitee-apim-portal-webui/src/app/services/analytics.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/analytics.service.ts
@@ -207,14 +207,25 @@ export class AnalyticsService {
       });
   }
 
-  private static buildQueryParam(queryParam, q: string) {
-    queryParam = q === 'body' ? '*' + queryParam + '*' : queryParam;
-    queryParam = q === 'uri' ? queryParam + '*' : queryParam;
-    if (queryParam !== '?') {
+  static buildQueryParam(queryParam, q: string) {
+    // use 'contains' wildcard for body parameter
+    if (q === 'body') {
+      queryParam = `*${this.escapeReservedCharacters(queryParam)}*`;
+    }
+    // use 'starts with' wildcard for uri parameter
+    else if (q === 'uri') {
+      queryParam = `${this.escapeReservedCharacters(queryParam)}*`;
+    }
+    // elsewhere, use quotes to match exact string
+    else if (queryParam !== '?') {
       queryParam = '\\"' + queryParam + '\\"';
       queryParam = queryParam.replace(/\//g, '\\\\/');
     }
     return queryParam;
+  }
+
+  private static escapeReservedCharacters(paramValue: string) {
+    return paramValue.replace(/(\+|-|=|&{2}|\|{2}|>|<|!|\(|\)|{|}|\[|]|\^|"|~|\?|:|\\|\/)/g, '\\\\$1');
   }
 
   getQueryFromPath(field?, ranges?) {


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6238

Logs search 'uri' parameter was wrongly quoted, so wasn't processed as a wildcard.
Slashes and special characters were not properly escaped too.

Retrieved the `escapeReservedCharacters` function from console's filter, to get the same filter behavior on portal and console.
To find all logs starting with this uri, according to console's filter behavior, parameter has to be like `query=uri:\\/my\\/url*`.

There are still some strange behaviors on body filter, for example if you search a string with a space, or a quote (in console and portal)
But this problem will be processes in another ticket, main 'url search' usecase is fixed (https://github.com/gravitee-io/issues/issues/6452)