### PR TITLE
Remove `HashLocationStrategy` and fix layout of NotificationTemplates

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.html
@@ -16,14 +16,14 @@
 
 -->
 <div class="org-settings-notification-templates">
-  <div>
+  <div class="org-settings-notification-templates__content">
     <h1>Templates</h1>
 
-    <mat-card *ngFor="let item of $any(notificationTemplatesByScope) | keyvalue" class="org-settings-notification-templates__card">
+    <mat-card *ngFor="let item of $any(notificationTemplatesByScope) | keyvalue" class="org-settings-notification-templates__content__card">
       <h2 gioTableOfContents>{{ item.key }}</h2>
-      <mat-list class="org-settings-notification-templates__list">
+      <mat-list class="org-settings-notification-templates__content__list">
         <mat-list-item
-          class="org-settings-notification-templates__list__item"
+          class="org-settings-notification-templates__content__list__item"
           *ngFor="let notificationTemplate of item.value"
           (click)="onEditActionClicked(notificationTemplate)"
         >

--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-templates.component.scss
@@ -15,15 +15,21 @@ $background: map.get(gio.$gio-theme, background);
   justify-content: space-between;
   align-items: flex-start;
 
-  &__card {
-    margin-bottom: 32px;
-  }
+  &__content {
+    // Hack to match place not used by the Table of Content
+    // Classic flex setup aren't working because of list's mat-line
+    width: 81%;
 
-  &__list {
-    &__item {
-      cursor: pointer;
-      &:hover {
-        background-color: mat.get-color-from-palette($background, hover);
+    &__card {
+      margin-bottom: 32px;
+    }
+
+    &__list {
+      &__item {
+        cursor: pointer;
+        &:hover {
+          background-color: mat.get-color-from-palette($background, hover);
+        }
       }
     }
   }

--- a/gravitee-apim-console-webui/src/shared/components/gio-policy-studio-wrapper/gio-policy-studio-wrapper.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-policy-studio-wrapper/gio-policy-studio-wrapper.component.html
@@ -42,7 +42,7 @@
     (:gv-policy-studio:fetch-documentation)="fetchPolicyDocumentation($event.detail)"
     (:gv-resources:fetch-documentation)="fetchResourceDocumentation($event.detail)"
     (:gv-expression-language:ready)="fetchSpelGrammar($event.detail)"
-    [attr.selected-flows-id]="selectedFlowsId ? readonlyPlans : null"
+    [attr.selected-flows-id]="selectedFlowsIds ? selectedFlowsIds : null"
     (:gv-policy-studio:select-flows)="onFlowSelectionChanged($event.detail)"
     (:gv-policy-studio:save)="save.emit($event.detail)"
   >

--- a/gravitee-apim-console-webui/src/shared/components/gio-policy-studio-wrapper/gio-policy-studio-wrapper.module.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-policy-studio-wrapper/gio-policy-studio-wrapper.module.ts
@@ -29,7 +29,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CommonModule, HashLocationStrategy, Location, LocationStrategy } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 
 import { GioPolicyStudioWrapperComponent } from './gio-policy-studio-wrapper.component';
@@ -39,7 +39,7 @@ import { GioPolicyStudioWrapperComponent } from './gio-policy-studio-wrapper.com
   declarations: [GioPolicyStudioWrapperComponent],
   exports: [GioPolicyStudioWrapperComponent],
   entryComponents: [GioPolicyStudioWrapperComponent],
-  providers: [Location, { provide: LocationStrategy, useClass: HashLocationStrategy }],
+  providers: [Location],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class GioPolicyStudioWrapperModule {}


### PR DESCRIPTION
**Issue**

NA

**Description**

 - Using `HashLocationStrategy` in `PolicyStudioWrapper` is breaking the Table of Content, so I removed this provider and updated the way we deal with the url.
 - NotificationTemplates' layout wasn't perfect due to `mat-line` element, to have a proper flex layout I forced the width of the content to 81% (complementary of the table of content width)
