### PR TITLE
fix: typo in the word order

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/analytics/analytics.html
+++ b/gravitee-apim-console-webui/src/management/configuration/analytics/analytics.html
@@ -94,11 +94,11 @@
         <md-button
           permission
           permission-only="'environment-dashboard-c'"
-          aria-label="Add dashboard {{type}}"
+          aria-label="Add {{type}} dashboard"
           ui-sref="management.settings.dashboardnew({type: type})"
           class="md-raised md-primary"
         >
-          Add a new dashboard {{type}}
+          Add a new {{type}} dashboard
         </md-button>
       </div>
     </div>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6363

**Description**

Set the right order in the words

```
Add a new dashboard platform --> Add a new platform dashboard
Add a new dashboard API --> Add a new API dashboard
Add a new dashboard application --> Add a new application dashboard
```
