### PR TITLE
fix: make Jettys threads use gravitee context class loader

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyQueuedThreadPool.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyQueuedThreadPool.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.standalone.jetty;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+/**
+ * JettyQueueThreadPool extends Jetty's default QueuedThreadPool,
+ * Overriding thread creation to make them use the Gravitee context class loader.
+ */
+public class JettyQueuedThreadPool extends QueuedThreadPool {
+
+    public JettyQueuedThreadPool(int poolMaxThreads, int poolMinThreads, int poolIdleTimeout, ArrayBlockingQueue<Runnable> queue) {
+        super(poolMaxThreads, poolMinThreads, poolIdleTimeout, queue);
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        Thread thread = super.newThread(runnable);
+        thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        return thread;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyServerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyServerFactory.java
@@ -41,7 +41,7 @@ public class JettyServerFactory implements FactoryBean<Server> {
     @Override
     public Server getObject() throws Exception {
         // Setup ThreadPool
-        QueuedThreadPool threadPool = new QueuedThreadPool(
+        QueuedThreadPool threadPool = new JettyQueuedThreadPool(
             jettyConfiguration.getPoolMaxThreads(),
             jettyConfiguration.getPoolMinThreads(),
             jettyConfiguration.getPoolIdleTimeout(),


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6290
https://github.com/gravitee-io/issues/issues/6494

Jetty version has been upgraded in this commit : https://github.com/gravitee-io/gravitee-bom/commit/6eb8566ef99700147a4eb018982490b448641ecc
It introduced mutliple regressions in APIM.

Since 9.4.37, Jettys threads classloaders have been refactored to fix a leak (see https://github.com/eclipse/jetty.project/pull/5894).
After this fix, threads classpath is override with local classpath, so it does not contain gravitee context class loader nomore (see https://github.com/eclipse/jetty.project/pull/5894/files#diff-6f0181889aa765771dd358e58fc07e2a7d7bfa44c451359e34e3eea574a5a79cR696).

Created a JettyQueuedThreadPool, to override Jetty's default QueuedThreadPool and give the gravitee context class loader to created threads.