### PR TITLE
Fix/rollback image io hack

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
@@ -16,7 +16,6 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.InlinePictureEntity;
 import io.gravitee.rest.api.model.MediaEntity;
@@ -154,13 +153,7 @@ public abstract class AbstractResource {
             }
 
             try {
-                /*
-                 * For an unknown reason, when running APIM from jar/zip instead of sourcecode, com.twelvemonkeys.imageio.stream.ByteArrayImageInputStreamSpi
-                 *  is not registered in the IIORegistry used by ImageIO to manage stream.
-                 * So basically the hack is to directly instantiate a ByteArrayImageInputStream
-                 */
-                //ImageInputStream imageInputStream = ImageIO.createImageInputStream(decodedPicture);
-                ImageInputStream imageInputStream = new ByteArrayImageInputStream(decodedPicture);
+                ImageInputStream imageInputStream = ImageIO.createImageInputStream(decodedPicture);
                 Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(imageInputStream);
 
                 while (imageReaders.hasNext()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/utils/ImageUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/utils/ImageUtils.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.security.utils;
 
-import com.twelvemonkeys.imageio.stream.ByteArrayImageInputStream;
 import io.gravitee.rest.api.exception.InvalidImageException;
 import java.awt.*;
 import java.awt.image.BufferedImage;
@@ -115,13 +114,7 @@ public final class ImageUtils {
 
     private static Image rescale(Image image, int width, int height) throws InvalidImageException {
         try {
-            /*
-             * For an unknown reason, when running APIM from jar/zip instead of sourcecode, com.twelvemonkeys.imageio.stream.ByteArrayImageInputStreamSpi
-             *  is not registered in the IIORegistry used by ImageIO to manage stream.
-             * So basically the hack is to directly instantiate a ByteArrayImageInputStream
-             */
-            //ImageInputStream imageInputStream = ImageIO.createImageInputStream(image.getData());
-            ImageInputStream imageInputStream = new ByteArrayImageInputStream(image.getData());
+            ImageInputStream imageInputStream = ImageIO.createImageInputStream(image.getData());
             Iterator<ImageReader> imageReaders = ImageIO.getImageReaders(imageInputStream);
 
             while (imageReaders.hasNext()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyQueuedThreadPool.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyQueuedThreadPool.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.standalone.jetty;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+/**
+ * JettyQueueThreadPool extends Jetty's default QueuedThreadPool,
+ * Overriding thread creation to make them use the Gravitee context class loader.
+ */
+public class JettyQueuedThreadPool extends QueuedThreadPool {
+
+    public JettyQueuedThreadPool(int poolMaxThreads, int poolMinThreads, int poolIdleTimeout, ArrayBlockingQueue<Runnable> queue) {
+        super(poolMaxThreads, poolMinThreads, poolIdleTimeout, queue);
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+        Thread thread = super.newThread(runnable);
+        thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        return thread;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyServerFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/jetty/JettyServerFactory.java
@@ -41,7 +41,7 @@ public class JettyServerFactory implements FactoryBean<Server> {
     @Override
     public Server getObject() throws Exception {
         // Setup ThreadPool
-        QueuedThreadPool threadPool = new QueuedThreadPool(
+        QueuedThreadPool threadPool = new JettyQueuedThreadPool(
             jettyConfiguration.getPoolMaxThreads(),
             jettyConfiguration.getPoolMinThreads(),
             jettyConfiguration.getPoolIdleTimeout(),


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6495
Jetty's classpath fix developed for 3.10.4, permits to rollback the hack made for image loading on master