### PR TITLE
chore: update openapi.yml path in update-sdk script

### DIFF
--- a/gravitee-apim-portal-webui/scripts/update-sdk.sh
+++ b/gravitee-apim-portal-webui/scripts/update-sdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 npx @openapitools/openapi-generator-cli@1.0.18-4.3.1 generate \
--i ../gravitee-api-management/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml \
+-i ../gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml \
 -g typescript-angular \
 -o projects/portal-webclient-sdk/src/lib/ \
 -puseSingleRequestParameter=true \


### PR DESCRIPTION
Update openapi.yml path in update-sdk script
Since portal is in the monorepository, openapi.yml path has to be updated.