### PR TITLE
chore: order of dependencies issues when building

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -143,6 +143,22 @@
 			<scope>runtime</scope>
 			<type>zip</type>
 		</dependency>
+
+		<dependency>
+			<groupId>io.gravitee.apim.repository</groupId>
+			<artifactId>gravitee-apim-repository-jdbc</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+			<type>zip</type>
+		</dependency>
+
+		<dependency>
+			<groupId>io.gravitee.apim.repository</groupId>
+			<artifactId>gravitee-apim-repository-mongodb</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+			<type>zip</type>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
As the `build` and the `test` jobs of the circleCI workflow execute the maven command with the `-T` option, there are some issues with dependencies between modules.

For instance, when packaging the full ZIP, we need the JDBC & Mongo repository to be packaged before starting. So this PR simply adds the missing dependencies to tell maven it has to wait for these 2 modules before beginning the build of the zip module.