### PR TITLE
chore(deps): update gravitee-cockpit-api to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,18 +425,6 @@
                 <version>${swagger-core.version}</version>
             </dependency>
 
-            <dependency>
-                <groupId>io.swagger.parser.v3</groupId>
-                <artifactId>swagger-parser</artifactId>
-                <version>${swagger-parser.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.github.fge</groupId>
-                        <artifactId>json-patch</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-
             <!-- JAXB API & implementation -->
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>1.9.0-SNAPSHOT</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.23.0-SNAPSHOT</gravitee-common.version>
         <gravitee-definition.version>1.30.0-SNAPSHOT</gravitee-definition.version>
         <gravitee-expression-language.version>1.7.1-SNAPSHOT</gravitee-expression-language.version>


### PR DESCRIPTION
Update the gravitee-cockpit-api version to fix `master` build.

The `maven` cache in CircleCI contains an outdated version of the 1.9.0-SNAPSHOT, that's why the build is failing