### PR TITLE
fix: clean gravitee context at the end of model deployment

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.cockpit.model.DeploymentMode;
 import io.gravitee.rest.api.service.cockpit.services.ApiServiceCockpit;
 import io.gravitee.rest.api.service.cockpit.services.CockpitApiPermissionChecker;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.Single;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -112,6 +113,8 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
         } catch (Exception e) {
             logger.error("Error occurred when importing api [{}].", payload.getModelId(), e);
             return Single.just(new DeployModelReply(command.getId(), CommandStatus.ERROR));
+        } finally {
+            GraviteeContext.cleanContext();
         }
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/1305

**Description**

I didn't know the roles were cached in the GraviteeContext, I've noticed other handlers (like [MembershipCommandHandler](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/MembershipCommandHandler.java#L129)) were cleaning the context so I do the same.