### PR TITLE
fix: use default environment when indexing users

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
@@ -62,7 +62,7 @@ public class CommandServiceImpl extends AbstractService implements CommandServic
 
         Command command = new Command();
         command.setId(RandomString.generate());
-        command.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        command.setEnvironmentId(GraviteeContext.getCurrentEnvironmentOrDefault());
         command.setFrom(node.id());
         command.setTo(messageEntity.getTo());
         command.setTags(convert(messageEntity.getTags()));


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6330

**Description**

When a user is created from the console, after a SSO login or a user registration from signup form, there is no Environment in the context.
As the command sent to the Lucene indexer requires an environment, we must provide at least a default environment.
