### PR TITLE
fix: do not exclude api definition to index an API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -37,7 +37,11 @@ public interface ApiService {
 
     Set<ApiEntity> findAll();
 
-    Set<ApiEntity> findAllLight();
+    default Set<ApiEntity> findAllLight() {
+        return findAllLight(true);
+    }
+
+    Set<ApiEntity> findAllLight(boolean excludeDefinition);
 
     Page<ApiEntity> findByUser(String userId, ApiQuery apiQuery, Sortable sortable, Pageable pageable, boolean portal);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -842,14 +842,19 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     @Override
-    public Set<ApiEntity> findAllLight() {
+    public Set<ApiEntity> findAllLight(boolean excludeDefinition) {
         try {
             LOGGER.debug("Find all APIs without some fields (definition, picture...)");
+            final ApiFieldExclusionFilter.Builder exclusionFilterBuilder = new ApiFieldExclusionFilter.Builder().excludePicture();
+            if (excludeDefinition) {
+                exclusionFilterBuilder.excludeDefinition();
+            }
+
             return new HashSet<>(
                 convert(
                     apiRepository.search(
                         new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
-                        new ApiFieldExclusionFilter.Builder().excludeDefinition().excludePicture().build()
+                        exclusionFilterBuilder.build()
                     )
                 )
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -63,8 +63,8 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
 
     @Override
     public boolean upgrade() {
-        // Index APIs
-        final Set<ApiEntity> apis = apiService.findAllLight();
+        // Index APIs. We need to keep definition, so we can index paths and hosts defined in the proxy field.
+        final Set<ApiEntity> apis = apiService.findAllLight(false);
 
         ExecutorService executorService = Executors.newFixedThreadPool(
             Runtime.getRuntime().availableProcessors() * 2,


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6565

**Description**

API definition is needed to provide paths and hosts.