### PR TITLE
Fix selection of log mode, content and scope in config screen

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-apim-console-webui",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/gravitee-apim-console-webui/src/libraries/gv-model.directive.ts
+++ b/gravitee-apim-console-webui/src/libraries/gv-model.directive.ts
@@ -39,6 +39,14 @@ class GvModelDirective {
         element.on(`${element[0].localName}:input`, (e) => {
           ngModel.$setViewValue(e.target.value);
         });
+
+        /*
+         * Some components emit different events, for instance:
+         *  - gv-option emits 'gv-option:select' event
+         */
+        element.on(`${element[0].localName}:select`, (e) => {
+          ngModel.$setViewValue(e.target.value);
+        });
       },
     };
   }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6282

**Description**

Only `*:input` events were bound to ngModel. However, some components emit different events, for instance:
 - gv-option emits 'gv-option:select' event

Now `*:select` events are also bound.
