### PR TITLE
fix: fix rollback API process causing plans inconsistencies in database

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -296,7 +296,7 @@ class ApiHistoryController {
 
   rollback(_apiPayload) {
     const _apiDefinition = JSON.parse(_apiPayload.definition);
-    delete _apiDefinition.id;
+    _apiDefinition.id = this.api.id;
     delete _apiDefinition.deployed_at;
     _apiDefinition.description = _apiPayload.description;
     _apiDefinition.visibility = _apiPayload.visibility;
@@ -348,6 +348,7 @@ class ApiHistoryController {
     delete payload.permission;
     delete payload.owner;
     delete payload.picture_url;
+    delete payload.background_url;
     delete payload.categories;
     delete payload.groups;
     delete payload.etag;
@@ -391,6 +392,7 @@ class ApiHistoryController {
       tags: eventPayloadDefinition.tags,
       proxy: eventPayloadDefinition.proxy,
       paths: eventPayloadDefinition.paths,
+      plans: eventPayloadDefinition.plans,
       flows: eventPayloadDefinition.flows,
       properties: eventPayloadDefinition.properties,
       services: eventPayloadDefinition.services,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -356,7 +356,7 @@ public class ApiResource extends AbstractResource {
         }
     )
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
-    public Response rollbackApi(@ApiParam(name = "api", required = true) @Valid @NotNull final UpdateApiEntity apiEntity) {
+    public Response rollbackApi(@ApiParam(name = "api", required = true) @Valid @NotNull final RollbackApiEntity apiEntity) {
         try {
             ApiEntity rollbackedApi = apiService.rollback(api, apiEntity);
             return Response

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/RollbackApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/RollbackApiEntity.java
@@ -1,0 +1,384 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.api;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.gravitee.definition.jackson.datatype.api.deser.PropertiesAsListDeserializer;
+import io.gravitee.definition.model.*;
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.plugins.resources.Resource;
+import io.gravitee.definition.model.services.Services;
+import io.gravitee.rest.api.model.ApiMetadataEntity;
+import io.gravitee.rest.api.model.DeploymentRequired;
+import io.gravitee.rest.api.model.Visibility;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.*;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class RollbackApiEntity {
+
+    @NotNull
+    @NotEmpty(message = "Api's id must not be empty")
+    @ApiModelProperty(value = "API's uuid.", example = "00f8c9e7-78fc-4907-b8c9-e778fc790750")
+    private String id;
+
+    @NotNull
+    @NotEmpty(message = "Api's name must not be empty")
+    @ApiModelProperty(value = "Api's name. Duplicate names can exists.", example = "My Api")
+    private String name;
+
+    @NotNull
+    @ApiModelProperty(value = "Api's version. It's a simple string only used in the portal.", example = "v1.0")
+    private String version;
+
+    @NotNull
+    @ApiModelProperty(
+        value = "API's description. A short description of your API.",
+        example = "I can use a hundred characters to describe this API."
+    )
+    private String description;
+
+    @NotNull
+    @JsonProperty(value = "proxy", required = true)
+    @ApiModelProperty(value = "API's definition.")
+    private Proxy proxy;
+
+    @JsonProperty(value = "paths", required = true)
+    @ApiModelProperty(value = "a map where you can associate a path to a configuration (the policies configuration)")
+    private Map<String, List<Rule>> paths = new HashMap<>();
+
+    @JsonProperty(value = "flows", required = true)
+    @ApiModelProperty(value = "a list of flows (the policies configuration)")
+    private List<Flow> flows = new ArrayList<>();
+
+    @JsonProperty(value = "plans", required = true)
+    @ApiModelProperty(value = "a list of plans with flows (the policies configuration)")
+    private List<Plan> plans = new ArrayList<>();
+
+    @ApiModelProperty(value = "The configuration of API services like the dynamic properties, the endpoint discovery or the healthcheck.")
+    private Services services;
+
+    @ApiModelProperty(value = "The list of API resources used by policies like cache resources or oauth2")
+    private List<Resource> resources = new ArrayList<>();
+
+    @JsonProperty(value = "properties")
+    @ApiModelProperty(value = "A dictionary (could be dynamic) of properties available in the API context.")
+    private Properties properties;
+
+    @NotNull
+    @ApiModelProperty(value = "The visibility of the API regarding the portal.", example = "PUBLIC", allowableValues = "PUBLIC, PRIVATE")
+    private Visibility visibility;
+
+    @ApiModelProperty(value = "the list of sharding tags associated with this API.", example = "public, private")
+    private Set<String> tags;
+
+    @ApiModelProperty(value = "the API logo encoded in base64")
+    private String picture;
+
+    @DeploymentRequired
+    @JsonProperty(value = "gravitee", required = false)
+    @ApiModelProperty(value = "API's gravitee definition version")
+    private String graviteeDefinitionVersion;
+
+    @DeploymentRequired
+    @JsonProperty(value = "flow_mode")
+    @ApiModelProperty(value = "API's flow mode.", example = "BEST_MATCH")
+    private FlowMode flowMode;
+
+    @JsonProperty("picture_url")
+    @ApiModelProperty(value = "the API logo URL")
+    private String pictureUrl;
+
+    @ApiModelProperty(value = "the list of categories associated with this API", example = "Product, Customer, Misc")
+    private Set<String> categories;
+
+    @ApiModelProperty(value = "the free list of labels associated with this API", example = "json, read_only, awesome")
+    private List<String> labels;
+
+    @ApiModelProperty(value = "API's groups. Used to add team in your API.", example = "['MY_GROUP1', 'MY_GROUP2']")
+    private Set<String> groups;
+
+    @JsonProperty(value = "path_mappings")
+    @ApiModelProperty(
+        value = "A list of paths used to aggregate data in analytics",
+        example = "/products/:productId, /products/:productId/media"
+    )
+    private Set<String> pathMappings;
+
+    @JsonProperty(value = "response_templates")
+    @ApiModelProperty(
+        value = "A map that allows you to configure the output of a request based on the event throws by the gateway. Example : Quota exceeded, api-ky is missing, ..."
+    )
+    private Map<String, Map<String, ResponseTemplate>> responseTemplates;
+
+    private List<ApiMetadataEntity> metadata;
+
+    @JsonProperty(value = "lifecycle_state")
+    private ApiLifecycleState lifecycleState;
+
+    @JsonProperty("disable_membership_notifications")
+    private boolean disableMembershipNotifications;
+
+    @ApiModelProperty(value = "the API background encoded in base64")
+    private String background;
+
+    @JsonProperty("background_url")
+    @ApiModelProperty(value = "the API background URL")
+    private String backgroundUrl;
+
+    public Visibility getVisibility() {
+        return visibility;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setVisibility(Visibility visibility) {
+        this.visibility = visibility;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Proxy getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(Proxy proxy) {
+        this.proxy = proxy;
+    }
+
+    public Map<String, List<Rule>> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(Map<String, List<Rule>> paths) {
+        this.paths = paths;
+    }
+
+    public Services getServices() {
+        return services;
+    }
+
+    public void setServices(Services services) {
+        this.services = services;
+    }
+
+    public Properties getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+
+    @JsonSetter("properties")
+    @JsonDeserialize(using = PropertiesAsListDeserializer.class)
+    public void setPropertyList(List<Property> properties) {
+        this.properties = new Properties();
+        this.properties.setProperties(properties);
+    }
+
+    @JsonGetter("properties")
+    public List<Property> getPropertyList() {
+        if (properties != null) {
+            return properties.getProperties();
+        }
+        return Collections.emptyList();
+    }
+
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Set<String> tags) {
+        this.tags = tags;
+    }
+
+    public String getPicture() {
+        return picture;
+    }
+
+    public void setPicture(String picture) {
+        this.picture = picture;
+    }
+
+    public List<Resource> getResources() {
+        return resources;
+    }
+
+    public void setResources(List<Resource> resources) {
+        this.resources = resources;
+    }
+
+    public Set<String> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(Set<String> categories) {
+        this.categories = categories;
+    }
+
+    public List<String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<String> labels) {
+        this.labels = labels;
+    }
+
+    public Set<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(Set<String> groups) {
+        this.groups = groups;
+    }
+
+    public Set<String> getPathMappings() {
+        return pathMappings;
+    }
+
+    public void setPathMappings(Set<String> pathMappings) {
+        this.pathMappings = pathMappings;
+    }
+
+    public Map<String, Map<String, ResponseTemplate>> getResponseTemplates() {
+        return responseTemplates;
+    }
+
+    public void setResponseTemplates(Map<String, Map<String, ResponseTemplate>> responseTemplates) {
+        this.responseTemplates = responseTemplates;
+    }
+
+    public List<ApiMetadataEntity> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(List<ApiMetadataEntity> metadata) {
+        this.metadata = metadata;
+    }
+
+    public ApiLifecycleState getLifecycleState() {
+        return lifecycleState;
+    }
+
+    public void setLifecycleState(ApiLifecycleState lifecycleState) {
+        this.lifecycleState = lifecycleState;
+    }
+
+    public boolean isDisableMembershipNotifications() {
+        return disableMembershipNotifications;
+    }
+
+    public void setDisableMembershipNotifications(boolean disableMembershipNotifications) {
+        this.disableMembershipNotifications = disableMembershipNotifications;
+    }
+
+    public String getBackground() {
+        return background;
+    }
+
+    public void setBackground(String background) {
+        this.background = background;
+    }
+
+    public String getBackgroundUrl() {
+        return backgroundUrl;
+    }
+
+    public void setBackgroundUrl(String backgroundUrl) {
+        this.backgroundUrl = backgroundUrl;
+    }
+
+    public String getPictureUrl() {
+        return pictureUrl;
+    }
+
+    public void setPictureUrl(String pictureUrl) {
+        this.pictureUrl = pictureUrl;
+    }
+
+    public List<Flow> getFlows() {
+        return flows;
+    }
+
+    public void setFlows(List<Flow> flows) {
+        this.flows = flows;
+    }
+
+    public List<Plan> getPlans() {
+        return plans;
+    }
+
+    public void setPlans(List<Plan> plans) {
+        this.plans = plans;
+    }
+
+    public String getGraviteeDefinitionVersion() {
+        return graviteeDefinitionVersion;
+    }
+
+    public void setGraviteeDefinitionVersion(String graviteeDefinitionVersion) {
+        this.graviteeDefinitionVersion = graviteeDefinitionVersion;
+    }
+
+    public void addPlan(Plan plan) {
+        this.plans.add(plan);
+    }
+
+    public FlowMode getFlowMode() {
+        return flowMode;
+    }
+
+    public void setFlowMode(FlowMode flowMode) {
+        this.flowMode = flowMode;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -89,7 +89,7 @@ public interface ApiService {
 
     ApiEntity deploy(String apiId, String userId, EventType eventType, ApiDeploymentEntity apiDeploymentEntity);
 
-    ApiEntity rollback(String apiId, UpdateApiEntity api);
+    ApiEntity rollback(String apiId, RollbackApiEntity api);
 
     String exportAsJson(String apiId, String exportVersion, String... filteredFields);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -251,6 +251,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Autowired
     private APIV1toAPIV2Converter apiv1toAPIV2Converter;
 
+    @Autowired
+    private ApiDuplicatorService apiDuplicatorService;
+
     @Value("${configuration.default-api-icon:}")
     private String defaultApiIcon;
 
@@ -1913,13 +1916,20 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     @Override
-    public ApiEntity rollback(String apiId, UpdateApiEntity api) {
+    public ApiEntity rollback(String apiId, RollbackApiEntity rollbackApiEntity) {
         LOGGER.debug("Rollback API : {}", apiId);
+
         try {
             // Audit
             auditService.createApiAuditLog(apiId, Collections.emptyMap(), API_ROLLBACKED, new Date(), null, null);
 
-            return update(apiId, api);
+            return apiDuplicatorService.updateWithImportedDefinition(
+                apiId,
+                objectMapper.writeValueAsString(rollbackApiEntity),
+                getAuthenticatedUsername(),
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment()
+            );
         } catch (Exception ex) {
             LOGGER.error("An error occurs while trying to rollback API: {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to rollback API: " + apiId, ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_RollbackTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_RollbackTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import static io.gravitee.repository.management.model.Api.AuditEvent.API_ROLLBACKED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.rest.api.model.api.RollbackApiEntity;
+import io.gravitee.rest.api.service.impl.ApiServiceImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiService_RollbackTest {
+
+    @InjectMocks
+    private ApiServiceImpl apiService = new ApiServiceImpl();
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private ApiDuplicatorService apiDuplicatorService;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void rollback_should_create_rollback_api_audit_log() {
+        RollbackApiEntity rollbackApiEntity = new RollbackApiEntity();
+
+        apiService.rollback("my-api-id", rollbackApiEntity);
+
+        verify(auditService, times(1)).createApiAuditLog(eq("my-api-id"), anyMap(), same(API_ROLLBACKED), any(), isNull(), isNull());
+    }
+
+    @Test
+    public void rollback_should_import_api_using_apiduplicator_service() throws JsonProcessingException {
+        RollbackApiEntity rollbackApiEntity = new RollbackApiEntity();
+        when(objectMapper.writeValueAsString(rollbackApiEntity)).thenReturn("my-serialized-api");
+
+        apiService.rollback("my-api-id", rollbackApiEntity);
+
+        verify(apiDuplicatorService, times(1)).updateWithImportedDefinition("my-api-id", "my-serialized-api", null, "DEFAULT", "DEFAULT");
+    }
+}


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6595

On API rollback, use the import process of the DuplicatorService to update the API.
It will ensure that plans are synchronized between api.definition and plans table.

We have to add to api ID to let now DuplicatorService that we update the same API, as it won't regenerate plans IDs.