### PR TITLE
chore: bump gravitee-parent to 20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.1</version>
+        <version>20.2-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim</groupId>


### PR DESCRIPTION
chore: bump gravitee-parent to 20.2
It makes APIM compatible with maven>=3.8.1, using https maven repositories only