### PR TITLE
fix: fix plans update from API import, keeping unspecified values

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -42,6 +43,7 @@ import io.gravitee.rest.api.service.jackson.ser.api.ApiSerializer;
 import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.vertx.core.buffer.Buffer;
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -111,7 +113,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
             createPageAndMedia(createdApiEntity, jsonNode, environmentId);
             updateApiReferences(createdApiEntity, jsonNode, organizationId, environmentId, false);
             return createdApiEntity;
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             LOGGER.error("An error occurs while trying to JSON deserialize the API {}", apiDefinition, e);
             throw new TechnicalManagementException("An error occurs while trying to JSON deserialize the API definition.");
         }
@@ -239,7 +241,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
             ApiEntity updatedApiEntity = apiService.update(apiId, importedApi, false);
             updateApiReferences(updatedApiEntity, jsonNode, organizationId, environmentId, true);
             return updatedApiEntity;
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             LOGGER.error("An error occurs while trying to JSON deserialize the API {}", apiDefinition, e);
             throw new TechnicalManagementException("An error occurs while trying to JSON deserialize the API definition.");
         }
@@ -377,7 +379,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         String environmentId,
         // FIXME: This whole method should be split in 2 (creation and update) and this flag should be removed
         boolean isUpdate
-    ) throws JsonProcessingException {
+    ) throws IOException {
         // Members
         final JsonNode membersToImport = jsonNode.path("members");
         if (membersToImport != null && membersToImport.isArray()) {
@@ -534,14 +536,13 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         //Plans
         final JsonNode plansDefinition = jsonNode.path("plans");
         if (plansDefinition != null && plansDefinition.isArray()) {
-            List<PlanEntity> plansToImport = objectMapper.readValue(
-                plansDefinition.toString(),
-                objectMapper.getTypeFactory().constructCollectionType(List.class, PlanEntity.class)
-            );
+            Map<String, PlanEntity> existingPlans = isUpdate
+                ? planService.findByApi(createdOrUpdatedApiEntity.getId()).stream().collect(toMap(PlanEntity::getId, plan -> plan))
+                : Collections.emptyMap();
 
-            if (isUpdate) {
-                findRemovedPlansIds(planService.findByApi(createdOrUpdatedApiEntity.getId()), plansToImport).forEach(planService::delete);
-            }
+            List<PlanEntity> plansToImport = readPlansToImportFromDefinition(plansDefinition, existingPlans);
+
+            findRemovedPlansIds(existingPlans.values(), plansToImport).forEach(planService::delete);
 
             plansToImport.forEach(
                 planEntity -> {
@@ -652,5 +653,20 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
 
     private Stream<String> findRemovedPlansIds(Collection<PlanEntity> existingPlans, Collection<PlanEntity> importedPlans) {
         return existingPlans.stream().filter(existingPlan -> !importedPlans.contains(existingPlan)).map(plan -> plan.getId());
+    }
+
+    private List<PlanEntity> readPlansToImportFromDefinition(JsonNode plansDefinition, Map<String, PlanEntity> existingPlans)
+        throws IOException {
+        List<PlanEntity> plansToImport = new ArrayList<>();
+        for (Iterator<JsonNode> it = plansDefinition.elements(); it.hasNext();) {
+            JsonNode planDefinition = it.next();
+            PlanEntity existingPlan = planDefinition.has("id") ? existingPlans.get(planDefinition.get("id").asText()) : null;
+            if (existingPlan != null) {
+                plansToImport.add(objectMapper.readerForUpdating(existingPlan).readValue(planDefinition));
+            } else {
+                plansToImport.add(objectMapper.readValue(planDefinition.toString(), PlanEntity.class));
+            }
+        }
+        return plansToImport;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api-update.definition+plans-missingData.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api-update.definition+plans-missingData.json
@@ -1,0 +1,125 @@
+{
+  "id": "id-api",
+  "name": "test",
+  "version": "1",
+  "description": "bmll",
+  "visibility": "PRIVATE",
+  "lifecycle_state": "CREATED",
+  "tags": [],
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://google.fr",
+        "weight": 1,
+        "backup": false,
+        "healthcheck": true
+      }
+    ],
+    "load_balancing": {
+      "type": "ROUND_ROBIN"
+    },
+    "failover": {
+      "maxAttempts": 1,
+      "retryTimeout": 0,
+      "cases": [
+        "TIMEOUT"
+      ]
+    },
+    "strip_context_path": false,
+    "http": {
+      "configuration": {
+        "connectTimeout": 5000,
+        "idleTimeout": 60000,
+        "keepAlive": true,
+        "dumpRequest": false,
+        "readTimeout": 10000,
+        "pipelining": false,
+        "maxConcurrentConnections": 100,
+        "useCompression": false
+      }
+    }
+  },
+  "paths": {
+    "/": [
+      {
+        "methods": [
+          "CONNECT",
+          "DELETE",
+          "GET",
+          "HEAD",
+          "OPTIONS",
+          "PATCH",
+          "POST",
+          "PUT",
+          "TRACE"
+        ],
+        "api-key": {}
+      },
+      {
+        "methods": [
+          "GET",
+          "POST",
+          "PUT",
+          "DELETE",
+          "HEAD",
+          "PATCH",
+          "OPTIONS",
+          "TRACE",
+          "CONNECT"
+        ],
+        "cache": {
+          "cacheName": null,
+          "key": null,
+          "timeToLiveSeconds": null,
+          "useResponseCacheHeaders": null,
+          "scope": null
+        },
+        "description": "Description of the Cache Gravitee Policy"
+      }
+    ]
+  },
+  "properties": {
+    "prop1": "value1"
+  },
+  "services": {},
+  "resources": [
+    {
+      "name": "cache_name",
+      "type": "cache",
+      "enabled": true,
+      "configuration": {
+        "name": "my-cache",
+        "timeToIdleSeconds": 1,
+        "timeToLiveSeconds": 2,
+        "maxEntriesLocalHeap": 1000
+      }
+    }
+  ],
+  "plans" : [
+    {
+      "id" : "plan-id1",
+      "name": "new name from imported description",
+      "validation" : "AUTO",
+      "security" : "API_KEY",
+      "type" : "API",
+      "status" : "PUBLISHED",
+      "api" : "id-api",
+      "order" : 0,
+      "paths" : {
+        "/" : [ {
+          "methods" : [ "GET" ],
+          "rate-limit" : {
+            "rate": {
+              "limit": 1,
+              "periodTime": 1,
+              "periodTimeUnit": "SECONDS"
+            }
+          },
+          "enabled" : true
+        } ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6595

fix: fix plans update from API import, keeping unspecified values

On rollback API, we use the import functionality, which updates plans according to json definition.
But this json definition doesn't contains all plans mandatory data.
So we have to keep the old plans data, and override them with the json definition content, instead of just recreating them from scratch.