### PR TITLE
test: add log for failures

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/AbstractWebSocketGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/AbstractWebSocketGatewayTest.java
@@ -16,12 +16,17 @@
 package io.gravitee.gateway.standalone.websocket;
 
 import io.gravitee.gateway.standalone.AbstractGatewayTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public abstract class AbstractWebSocketGatewayTest extends AbstractGatewayTest {
+
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
     static {
         System.setProperty("vertx.disableWebsockets", Boolean.FALSE.toString());
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.standalone.websocket;
 
-import io.gravitee.gateway.standalone.AbstractGatewayTest;
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
 import io.vertx.core.Vertx;
@@ -64,6 +63,7 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
             "/test",
             event -> {
                 if (event.failed()) {
+                    logger.error("An error occurred during websocket call", event.cause());
                     Assert.fail();
                 } else {
                     final WebSocket webSocket = event.result();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -71,6 +71,7 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
             "/test",
             event -> {
                 if (event.failed()) {
+                    logger.error("An error occurred during websocket call", event.cause());
                     Assert.fail();
                 } else {
                     final WebSocket webSocket = event.result();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
@@ -64,6 +64,7 @@ public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
             "/test",
             event -> {
                 if (event.failed()) {
+                    logger.error("An error occurred during websocket call", event.cause());
                     Assert.fail();
                 } else {
                     final WebSocket webSocket = event.result();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
@@ -70,6 +70,7 @@ public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
             "/test",
             event -> {
                 if (event.failed()) {
+                    logger.error("An error occurred during websocket call", event.cause());
                     Assert.fail();
                 } else {
                     final WebSocket webSocket = event.result();


### PR DESCRIPTION
**Description**

Sometimes, Websocket unit tests fail on CI, and we don't have any clue for the root cause.
This PR adds logs, hoping that could help.