### PR TITLE
Keep the search score order when searching API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -876,7 +876,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             List<Api> allApis = findApisByUser(userId, apiQuery, portal);
 
-            final Page<Api> apiPage = sortAndPaginate(allApis, sortable, pageable);
+            final Page<Api> apiPage = sortAndPaginate(
+                allApis,
+                pageable,
+                buildApiComparator(sortable, pageable, allApis, comparing(api -> api.getName().toLowerCase()))
+            );
 
             // merge all apis
             final List<ApiEntity> apis = convert(apiPage.getContent());
@@ -2526,10 +2530,15 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             // We need to sort on fields which cannot be sort using db engine (ex: api's definition fields). Retrieve all the apis, then sort and paginate in memory.
             // Pictures are not required when looking for APIs
+            final List<Api> search = apiRepository.search(
+                queryToCriteria(query).build(),
+                new ApiFieldExclusionFilter.Builder().excludePicture().build()
+            );
+
             Page<Api> apiPage = sortAndPaginate(
-                apiRepository.search(queryToCriteria(query).build(), new ApiFieldExclusionFilter.Builder().excludePicture().build()),
-                sortable,
-                pageable
+                search,
+                pageable,
+                buildApiComparator(sortable, pageable, search, comparing(api -> api.getName().toLowerCase()))
             );
 
             // Unfortunately, for now, filterApiByQuery can't be invoked because it could break pagination and sort.
@@ -2585,7 +2594,12 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             }
 
             final ApiCriteria apiCriteria = new ApiCriteria.Builder().ids(matchApis.getDocuments().toArray(new String[0])).build();
-            final Page<Api> apiPage = sortAndPaginate(apiRepository.search(apiCriteria), sortable, pageable);
+            final Page<Api> apiPage = sortAndPaginate(
+                apiRepository.search(apiCriteria),
+                pageable,
+                // Keep order done by `searchEngineService` (based on score)
+                buildApiComparator(sortable, pageable, apiRepository.search(apiCriteria), (api1, api2) -> 0)
+            );
 
             // merge all apis
             final List<ApiEntity> apis = convert(apiPage.getContent());
@@ -3279,8 +3293,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     /*
         Sort then paginate the provided list of apis.
      */
-    private Page<Api> sortAndPaginate(List<Api> apis, Sortable sortable, Pageable pageable) {
-        Comparator<Api> comparator = buildApiComparator(sortable, pageable, apis);
+    private Page<Api> sortAndPaginate(List<Api> apis, Pageable pageable, final Comparator<Api> comparator) {
         pageable = buildPageable(pageable);
 
         int totalCount = apis.size();
@@ -3312,12 +3325,17 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         Depending on the field to compare, it maintains a map of api definitions internally.
         This increase the complexity but avoid unnecessary multiple json deserialization
      */
-    private Comparator<Api> buildApiComparator(Sortable sortable, Pageable pageable, List<Api> apis) {
+    private Comparator<Api> buildApiComparator(
+        Sortable sortable,
+        Pageable pageable,
+        List<Api> apis,
+        final Comparator<Api> paginationDefaultComparator
+    ) {
         Comparator<Api> comparator = (api1, api2) -> 0;
 
         if (pageable != null) {
             // Pagination requires sorting apis to be able to navigate through pages.
-            comparator = comparing(api -> api.getName().toLowerCase());
+            comparator = paginationDefaultComparator;
         }
 
         if (sortable != null) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5744

**Description**

Previously a default sort was done in all calls to API search methods.
This alphabetical sort was always the same and based on API's name.

However, in some cases like console API search based on a term we definitely want to keep the search score order.
So we can now provide a default comparator in `sortAndPaginate` method and:
 - keep alphabetical sort when listing all APIs of a user
 - provide a no-op comparator when searching APIs with a term


