### PR TITLE
chore: sync release.json and pom.xml

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-policy-json-validation.version>1.6.0</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>1.0.0</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>1.20.0</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>1.21.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>1.1.0</gravitee-policy-metrics-reporter.version>
@@ -104,13 +104,14 @@
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
-        <gravitee-repository-elasticsearch.version>3.8.1</gravitee-repository-elasticsearch.version>
+        <gravitee-repository-elasticsearch.version>3.9.0</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.8.1</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.9.0</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.4.3</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->
         <!--	<gravitee-gateway-services-ratelimit.version>1.13.0</gravitee-gateway-services-ratelimit.version>	-->
+        <gravitee-tracer-jaeger.version>1.0.0</gravitee-tracer-jaeger.version>
 
     </properties>
 
@@ -590,6 +591,24 @@
                                         <groupId>io.gravitee.policy</groupId>
                                         <artifactId>gravitee-gateway-services-ratelimit</artifactId>
                                         <version>${gravitee-policy-ratelimit.version}</version>
+                                        <type>zip</type>
+                                    </artifactItem>
+                                </artifactItems>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>copy-tracers</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>copy</goal>
+                            </goals>
+                            <configuration>
+                                <outputDirectory>${basedir}/target/staging/tracers</outputDirectory>
+                                <artifactItems>
+                                    <artifactItem>
+                                        <groupId>io.gravitee.tracer</groupId>
+                                        <artifactId>gravitee-tracer-jaeger</artifactId>
+                                        <version>${gravitee-tracer-jaeger.version}</version>
                                         <type>zip</type>
                                     </artifactItem>
                                 </artifactItems>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly.xml
@@ -136,6 +136,14 @@
         </fileSet>
 
         <fileSet>
+            <directory>target/staging/tracers</directory>
+            <outputDirectory>plugins</outputDirectory>
+            <includes>
+                <include>*.zip</include>
+            </includes>
+        </fileSet>
+
+        <fileSet>
             <directory>target/staging</directory>
             <outputDirectory>boot</outputDirectory>
             <includes>


### PR DESCRIPTION
**Description**

This PR synchronizes the versions of some dependencies in release.json file and those in the APIM distribution pom.xml.
The goal is to have the same thing on public and private docker images