### PR TITLE
fix(heartbeat): avoid infinite heartbeat event loop

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatService.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class HeartbeatService extends AbstractService implements MessageListener<Event>, InitializingBean {
+public class HeartbeatService extends AbstractService<HeartbeatService> implements MessageListener<Event>, InitializingBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatService.class);
 
@@ -124,8 +124,7 @@ public class HeartbeatService extends AbstractService implements MessageListener
             heartbeatEvent = prepareEvent();
             topic.publish(heartbeatEvent);
 
-            // Remove the state to not include it in the underlying repository as it's just used for internal
-            // purpose
+            // Remove the state to not include it in the underlying repository as it's just used for internal purpose
             heartbeatEvent.getProperties().remove(EVENT_STATE_PROPERTY);
 
             executorService = Executors.newSingleThreadScheduledExecutor(
@@ -154,16 +153,20 @@ public class HeartbeatService extends AbstractService implements MessageListener
                 } else {
                     eventRepository.update(event);
                 }
-            } catch (Exception ex) {
-                LOGGER.error("An error occurs while pushing heartbeat event id[{}] type[{}]", event.getId(), event.getType(), ex);
-                // Push back the event into the topic in case of error
+            } catch (IllegalStateException isex) {
+                // We make the assumption that an IllegalStateException is thrown when trying to update the event while it is not existing in the database anymore.
+                // This can be cause, for instance, by a db event cleanup without taking care of the heartbeat event.
+                event.getProperties().put(EVENT_STATE_PROPERTY, "recreate");
                 topic.publish(event);
+            } catch (Exception ex) {
+                // We assume to loose the event if something goes wrong and not republish it to avoid infinite loop and cpu starving. It will be overridden by the next heartbeat event.
+                LOGGER.warn("An error occurred while pushing heartbeat event id[{}] type[{}]. Message is: {}", event.getId(), event.getType(), ex.getMessage());
             }
         }
     }
 
     @Override
-    public Object preStop() throws Exception {
+    public HeartbeatService preStop() throws Exception {
         if (enabled) {
             heartbeatEvent.setType(EventType.GATEWAY_STOPPED);
             heartbeatEvent.getProperties().put(EVENT_STOPPED_AT_PROPERTY, Long.toString(new Date().getTime()));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/HeartbeatServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/HeartbeatServiceTest.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.heartbeat;
+
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.Message;
+import io.gravitee.common.utils.UUID;
+import io.gravitee.node.api.cluster.ClusterManager;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EventRepository;
+import io.gravitee.repository.management.model.Event;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.gravitee.gateway.services.heartbeat.HeartbeatService.EVENT_STATE_PROPERTY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HeartbeatServiceTest {
+
+    @Mock
+    private ClusterManager clusterManager;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private ITopic<Event> topic;
+
+    @Mock
+    private Message<Event> message;
+
+    @InjectMocks
+    private HeartbeatService cut;
+
+    @Test
+    public void shouldCreateEvent() throws TechnicalException {
+        Event event = new Event();
+        event.setId(UUID.toString(UUID.random()));
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(EVENT_STATE_PROPERTY, "create");
+        event.setProperties(properties);
+
+        when(clusterManager.isMasterNode()).thenReturn(true);
+        when(message.getMessageObject()).thenReturn(event);
+        cut.onMessage(message);
+
+        verify(eventRepository).create(event);
+    }
+
+    @Test
+    public void shouldUpdateEvent() throws TechnicalException {
+        Event event = new Event();
+        event.setId(UUID.toString(UUID.random()));
+        event.setProperties(new HashMap<>());
+
+        when(clusterManager.isMasterNode()).thenReturn(true);
+        when(message.getMessageObject()).thenReturn(event);
+        cut.onMessage(message);
+
+        verify(eventRepository).update(event);
+    }
+
+    @Test
+    public void shouldRepublishEventWhenIllegalArgumentExceptionIsThrown() throws TechnicalException {
+        Event event = new Event();
+        event.setId(UUID.toString(UUID.random()));
+        event.setProperties(new HashMap<>());
+
+        when(clusterManager.isMasterNode()).thenReturn(true);
+        when(message.getMessageObject()).thenReturn(event);
+        when(eventRepository.update(event)).thenThrow(new IllegalStateException(String.format("No event found with id [%s]", event.getId())));
+        cut.onMessage(message);
+
+        verify(topic).publish(event);
+        assertEquals("recreate", event.getProperties().get(EVENT_STATE_PROPERTY));
+    }
+
+    @Test
+    public void shouldNotRepublishEventWhenTechnicalExceptionIsThrown() throws TechnicalException {
+        Event event = new Event();
+        event.setId(UUID.toString(UUID.random()));
+        event.setProperties(new HashMap<>());
+
+        when(clusterManager.isMasterNode()).thenReturn(true);
+        when(message.getMessageObject()).thenReturn(event);
+        when(eventRepository.update(event)).thenThrow(new TechnicalException("Connection timeout"));
+        cut.onMessage(message);
+
+        verifyNoInteractions(topic);
+        assertTrue(event.getProperties().isEmpty());
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6655

**Description**

Avoid infinite loop when sending heartbeat event while error occurs.