### PR TITLE
fix(hc): start enpoint hc service before apis sync

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckService.java
@@ -36,9 +36,8 @@ public class EndpointHealthcheckService extends AbstractService {
     private String deploymentId;
 
     @Override
-    protected void doStart() throws Exception {
-        super.doStart();
-
+    public Object preStart() throws Exception {
+        // Start the service on the preStart phase to be ready when other services will start.
         final EndpointHealthcheckVerticle healthcheckVerticle = new EndpointHealthcheckVerticle();
         applicationContext.getAutowireCapableBeanFactory().autowireBean(healthcheckVerticle);
 
@@ -49,6 +48,12 @@ public class EndpointHealthcheckService extends AbstractService {
 
             deploymentId = event.result();
         });
+        return this;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
     }
 
     @Override


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6657

**Description**

Make sure the `EndpointHealthCheckService` is listening api deploy event before starting the first api synchronization.