### PR TITLE
chore: use latest gravitee-elasticsearch version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -820,4 +820,3 @@
         </plugins>
     </build>
 </project>
-


### PR DESCRIPTION
**Description**

Modify pom.xml to force circleCI to not use an old cache
